### PR TITLE
Bump SageMath base image to 10.9 and fix hardcoded sage UID

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Keep the build context small. Without this, `COPY . /workspace` ingests the
+# local .venv and .git, which makes the `chown -R` layer extremely slow and
+# bakes a host-built virtualenv into the image. CI creates .venv before running
+# `docker compose up --build`, so this matters there too.
+.venv
+.git
+.github
+.pytest_cache
+.ruff_cache
+.mypy_cache
+__pycache__/
+*.pyc
+.coverage
+htmlcov
+dist
+build
+*.egg-info
+integration.log
+integration-artifacts.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     needs: [lint, test]
     services:
       sage:
-        image: sagemath/sagemath:10.5
+        image: sagemath/sagemath:10.9
         options: --name sage-mcp-ci
     steps:
       - uses: actions/checkout@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - `uv pip install -e .[dev]` primes the venv with runtime+dev extras; prefer `sage -python -m uv ...` inside the Docker image.
 - `make sage-container` (script: `scripts/setup_sage_container.sh`) ensures the Sage runtime is available for integration work.
 - Keep `TODO.md` in sync with outstanding initiatives; the unchecked items at the bottom reflect the current priority queue.
-- `docker-compose.yml` spins up the Sage-backed MCP server locally; the Helm chart under `charts/sagemath-mcp` mirrors the deployment knobs for Kubernetes and enforces the non-root `sage` user (UID/GID 1000).
+- `docker-compose.yml` spins up the Sage-backed MCP server locally; the Helm chart under `charts/sagemath-mcp` mirrors the deployment knobs for Kubernetes and enforces the non-root `sage` user (UID/GID 1001 on SageMath 10.9).
 - Release workflow publishes signed images to `ghcr.io/xbp-europe/sagemath-mcp`; verify with Cosign if you consume the container directly.
 - Configure Git hooks after cloning: `git config core.hooksPath .githooks` (pre-push runs `uv run ruff check`).
 - Use `scripts/run_ci_simulation.sh` to approximate `.github/workflows/ci.yml` locally (requires Docker, Helm, uv).
@@ -36,4 +36,4 @@ All items from the original TODO are complete. See `TODO.md` for the full checkl
 - Use `cancel_sage_session` instead of force-stopping long Sage computations.
 - Keep comments concise; explain non-obvious security or monitoring decisions inline.
 - Capture and attach integration artifacts/logs when debugging or updating CI.
-- Containerized workflows expect writable volumes for UID/GID 1000; adjust permissions when mounting host paths.
+- Containerized workflows expect writable volumes for UID/GID 1001 (the `sage` user in SageMath 10.9); adjust permissions when mounting host paths.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Ruff with line-length 100, target Python 3.12. Rules: E, F, W, B, UP, ASYNC, RUF
 - **stdio** (default, for Claude Desktop): `uv run sagemath-mcp`
 - **HTTP**: `uv run sagemath-mcp --transport streamable-http --host 127.0.0.1 --port 8314`
 - **Docker Compose**: `docker compose up --build` (port 8314)
-- **Kubernetes**: Helm chart in `charts/sagemath-mcp/`; enforces non-root user (UID/GID 1000)
+- **Kubernetes**: Helm chart in `charts/sagemath-mcp/`; enforces non-root user (UID/GID 1001, matching `sage` in SageMath 10.9)
 
 ## CI/CD
 
@@ -67,4 +67,4 @@ Ruff with line-length 100, target Python 3.12. Rules: E, F, W, B, UP, ASYNC, RUF
 - Configure Git hooks after cloning: `git config core.hooksPath .githooks` (pre-push runs ruff).
 - Update `README.md`, `USAGE.md`, and monitoring docs when changing CLI flags, security toggles, or observability.
 - Use `cancel_sage_session` instead of force-stopping long computations.
-- Containerized workflows expect writable volumes for UID/GID 1000.
+- Containerized workflows expect writable volumes for UID/GID 1001 (the `sage` user in SageMath 10.9).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sagemath/sagemath:10.5
+FROM sagemath/sagemath:10.9
 
 WORKDIR /workspace
 

--- a/EVALUATION.md
+++ b/EVALUATION.md
@@ -11,7 +11,7 @@ The project delivers a comprehensive mathematics MCP server with 33 tools (31 Sa
 - **33 MCP tools** (30 Sage-backed) covering calculus, algebra, linear algebra, ODEs, number theory, combinatorics, graph theory, group theory, elliptic curves, coding theory, boolean algebra, polynomial rings, geometry, probability, vector calculus, statistics, and visualization — plus the open-ended `evaluate_sage` escape hatch
 - **Stateful sessions** — persistent Sage worker per client, variables survive across calls
 - **Security** — AST-based validation blocking dangerous operations, configurable policy
-- **Infrastructure** — Docker (pinned to SageMath 10.5), Helm with health probes, CI/CD with 6 parallel jobs, pip-audit, coverage reporting
+- **Infrastructure** — Docker (pinned to SageMath 10.9), Helm with health probes, CI/CD with 6 parallel jobs, pip-audit, coverage reporting
 - **Testing** — 242 unit tests at 99% branch coverage, plus 43 CLI integration tests across 9 math domains
 - **`evaluate_sage`** — enriched tool description with domain-specific examples so LLMs know what Sage can do
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Python](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![MCP](https://img.shields.io/badge/MCP-Model%20Context%20Protocol-purple)](https://modelcontextprotocol.io/)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.2-green.svg)](https://gofastmcp.com/)
-[![SageMath](https://img.shields.io/badge/SageMath-10.5-orange)](https://www.sagemath.org/)
+[![SageMath](https://img.shields.io/badge/SageMath-10.9-orange)](https://www.sagemath.org/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://docs.astral.sh/ruff/)
 [![Typed](https://img.shields.io/badge/type--checked-py.typed-blue)](https://peps.python.org/pep-0561/)
 
@@ -1110,7 +1110,7 @@ A new end-to-end test suite validates the MCP server through real LLM CLI invoca
 - **GitHub Actions Node.js 24** --- all actions bumped: `checkout@v5`, `setup-uv@v7`, `setup-python@v6`, `download-artifact@v6`, `build-push-action@v6`, `upload-artifact@v4`.
 
 **Docker:**
-- Base image pinned from `sagemath/sagemath:latest` to `sagemath/sagemath:10.5` for reproducible builds. The `latest` tag was non-deterministic and could break builds when SageMath released new versions.
+- Base image pinned from `sagemath/sagemath:latest` to a pinned release (currently `sagemath/sagemath:10.9`) for reproducible builds. The `latest` tag was non-deterministic and could break builds when SageMath released new versions.
 
 **Kubernetes (Helm chart):**
 - Added **liveness probe** (TCP socket on HTTP port, 30s initial delay, 15s period, 3 failure threshold) --- restarts the pod if the server becomes unresponsive.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,7 @@ All items from the initial evaluation and TODO have been implemented:
 - [x] 242 unit tests at 99% branch coverage
 - [x] FastMCP 3.x upgrade with full API migration
 - [x] CI modernization (6 parallel jobs, matrix testing, uv caching, pip-audit, coverage)
-- [x] Docker image pinned to SageMath 10.5
+- [x] Docker image pinned to SageMath 10.9
 - [x] Helm chart health probes (liveness, readiness, startup)
 - [x] Python 3.12+ minimum
 - [x] All GitHub Actions on Node.js 24

--- a/charts/sagemath-mcp/values.yaml
+++ b/charts/sagemath-mcp/values.yaml
@@ -17,16 +17,20 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
+# UID/GID must match the `sage` account in the base image (SageMath 10.9 uses
+# 1001; 10.5 and earlier used 1000). /home/sage is mode 0750, so a mismatched
+# UID cannot traverse it and the container fails to start. Update these
+# together with the base image in the Dockerfile.
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
-  fsGroup: 1000
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
 
 securityContext:
   runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
+  runAsUser: 1001
+  runAsGroup: 1001
   allowPrivilegeEscalation: false
   capabilities:
     drop:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,10 @@ services:
       dockerfile: Dockerfile
     image: sagemath-mcp:local
     container_name: sage-mcp
-    user: "1000:1000"
+    # No hardcoded user: the image already runs as the base image's `sage`
+    # account. Pinning a numeric UID here breaks whenever upstream renumbers it
+    # (sage moved from uid 1000 to 1001 between SageMath 10.5 and 10.9, and
+    # /home/sage is mode 0750, so a wrong UID cannot even reach /usr/bin/sage).
     restart: unless-stopped
     ports:
       - "8314:8314"


### PR DESCRIPTION
Supersedes #13, which bumped only the Dockerfile and failed the smoke test.

## Root cause of #13's failure

The `sage` account was renumbered upstream:

| | 10.5 | 10.9 |
|---|---|---|
| `sage` user | uid=1000 gid=1000 | **uid=1001 gid=1001** |
| `/home/sage` | — | `drwxr-x---` (0750), sage-only |

`docker-compose.yml` hardcoded `user: "1000:1000"`. On 10.9 that UID is no longer `sage` and cannot traverse the 0750 `/home/sage` to reach the `/usr/bin/sage` → `/home/sage/sage/sage` symlink target, so the container died at startup:

```
/bin/sh: 0: cannot open /usr/bin/sage: Permission denied
```

The server never bound its port, so the smoke client hung in `initialize()` until cancelled — which is the `CancelledError` traceback in the CI log, several layers removed from the actual cause.

## Changes

- **Dockerfile and `ci.yml` integration service** both moved to 10.9. #13 left `ci.yml:80` on 10.5, so the integration job never exercised the new image.
- **`docker-compose.yml`** no longer hardcodes a UID. The image already runs as its own `sage` account, which stays correct across future renumbering.
- **Helm `values.yaml`** moves to 1001. `runAsNonRoot` needs an explicit UID, so this one cannot simply be dropped — it is commented to be updated alongside the base image. **This would have broken Kubernetes deployments silently**, not just CI.
- **Added `.dockerignore`.** Without it `COPY . /workspace` ingests `.venv` (83 MB) and `.git`, making the `chown -R` layer take minutes. The smoke job runs `uv venv` before `docker compose up --build`, so CI was baking a host-built virtualenv into the image.
- Docs and UID references updated (README badge, EVALUATION, ROADMAP, CLAUDE.md, AGENTS.md).

## Verification

Run locally against 10.9:

- container starts cleanly and binds 8314
- `scripts/exercise_mcp.py` passes end to end — connect, stateful evaluate (`42`), progress events, cancel/restart
- the monitoring-metrics resource check passes (`attempts=3 successes=2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA