### PR TITLE
Fix solve_ode rejecting the documented y(x) form (#12)

### DIFF
--- a/src/sagemath_mcp/server.py
+++ b/src/sagemath_mcp/server.py
@@ -755,17 +755,31 @@ async def solve_ode(
         + textwrap.dedent(
             f"""
         _x = var({_encode_literal(variable)})
-        _y = function({_encode_literal(function)})(_x)
-        _ode_locals = dict(_locals)
-        _ode_locals[{_encode_literal(function)}] = _y
-        _ode_locals['diff'] = diff
-        parts = {_encode_literal(equation)}.split('=')
-        if len(parts) == 2:
-            left = sage_eval(parts[0].strip(), locals=_ode_locals)
-            right = sage_eval(parts[1].strip(), locals=_ode_locals)
-            _ode = left == right
-        else:
-            _ode = sage_eval({_encode_literal(equation)}, locals=_ode_locals)
+        _ode_function = function({_encode_literal(function)})
+        _y = _ode_function(_x)
+        _ode_text = {_encode_literal(equation)}
+
+        def _build_ode(_binding):
+            _ode_locals = dict(_locals)
+            _ode_locals[{_encode_literal(function)}] = _binding
+            _ode_locals['diff'] = diff
+            parts = _ode_text.split('=')
+            if len(parts) == 2:
+                left = sage_eval(parts[0].strip(), locals=_ode_locals)
+                right = sage_eval(parts[1].strip(), locals=_ode_locals)
+                return left == right
+            return sage_eval(_ode_text, locals=_ode_locals)
+
+        # Bind the bare name to the undefined function so the documented
+        # "diff(y(x), x)" form parses. Binding the applied expression instead
+        # turns "y(x)" into "(y(x))(x)", which Sage rejects with "Substitution
+        # using function-call syntax and unnamed arguments has been removed".
+        # Fall back to the applied expression so a bare "diff(y, x)" still
+        # works, since that form cannot be parsed against the function itself.
+        try:
+            _ode = _build_ode(_ode_function)
+        except Exception:
+            _ode = _build_ode(_y)
         str(desolve(_ode, _y, ivar=_x))
         """
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -130,3 +130,74 @@ async def test_monitoring_metrics_on_cancellation(monkeypatch):
         assert snapshot["successes"] >= 1
     finally:
         await manager.shutdown()
+
+
+@requires_sage
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("equation", "function", "variable", "expected"),
+    [
+        # The documented form from the tool's own docstring. This is the exact
+        # call reported in issue #12.
+        ("diff(y(x), x) + y(x) = cos(x)", "y", "x", ("_C", "cos(x)", "sin(x)")),
+        # The bare form, which worked before the fix and must keep working:
+        # the fix must not simply trade one broken spelling for another.
+        ("diff(y, x) + y = cos(x)", "y", "x", ("_C", "cos(x)", "sin(x)")),
+        # Second order, both spellings.
+        ("diff(y(x), x, 2) + y(x) = 0", "y", "x", ("_K1", "_K2")),
+        ("diff(y, x, 2) + y = 0", "y", "x", ("_K1", "_K2")),
+        # "==" takes the non-split branch through the generated code.
+        ("diff(y(x), x) == y(x)", "y", "x", ("_C", "e^x")),
+        # The applied/bare handling must not assume the names y and x.
+        ("diff(f(t), t) = f(t)", "f", "t", ("_C", "e^t")),
+        ("diff(y(x), x) = x*y(x)", "y", "x", ("_C", "e^")),
+    ],
+)
+async def test_solve_ode_equation_forms(monkeypatch, equation, function, variable, expected):
+    """Regression test for #12: solve_ode rejected the documented "y(x)" form.
+
+    The generated Sage code bound the dependent name to the *applied*
+    expression y(x), so "y(x)" in the user's equation became "(y(x))(x)" and
+    Sage raised "Substitution using function-call syntax and unnamed arguments
+    has been removed". Every spelling below must now solve.
+    """
+
+    settings = SageSettings(force_python_worker=False)
+    manager = SageSessionManager(settings)
+    monkeypatch.setattr(server, "SESSION_MANAGER", manager)
+    ctx = FakeContext("integration-ode-forms")
+
+    try:
+        result = await server.solve_ode(
+            equation, function=function, variable=variable, ctx=ctx
+        )
+        solution = str(result["solution"])
+
+        # The exact failure reported in #12 must not resurface.
+        assert "Substitution using function-call syntax" not in solution
+        for fragment in expected:
+            assert fragment in solution, f"{fragment!r} missing from {solution!r}"
+    finally:
+        await manager.shutdown()
+
+
+@requires_sage
+@pytest.mark.asyncio
+async def test_solve_ode_applied_and_bare_agree(monkeypatch):
+    """#12: the two spellings describe one ODE, so they must solve identically."""
+
+    settings = SageSettings(force_python_worker=False)
+    manager = SageSessionManager(settings)
+    monkeypatch.setattr(server, "SESSION_MANAGER", manager)
+    ctx = FakeContext("integration-ode-agree")
+
+    try:
+        applied = await server.solve_ode(
+            "diff(y(x), x) + y(x) = cos(x)", function="y", variable="x", ctx=ctx
+        )
+        bare = await server.solve_ode(
+            "diff(y, x) + y = cos(x)", function="y", variable="x", ctx=ctx
+        )
+        assert str(applied["solution"]) == str(bare["solution"])
+    finally:
+        await manager.shutdown()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -647,6 +647,28 @@ async def test_solve_ode(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_solve_ode_binds_undefined_function(monkeypatch):
+    """Regression guard for #12 that does not need a Sage runtime.
+
+    Binding the dependent name to the applied expression turns the documented
+    "y(x)" spelling into "(y(x))(x)", which Sage rejects. The generated code
+    must bind the undefined function and only fall back to the applied form.
+    """
+
+    session = StubSession("'_C*e^(-x)'")
+    await _stub_manager(monkeypatch, session)
+    ctx = FakeContext()
+    await server.solve_ode("diff(y(x), x) + y(x) = cos(x)", ctx=ctx)
+
+    code = session.calls[0]["code"]
+    assert "_ode_function = function(\"y\")" in code
+    assert "_build_ode(_ode_function)" in code
+    # The applied expression is still available as the fallback binding.
+    assert "_y = _ode_function(_x)" in code
+    assert "_build_ode(_y)" in code
+
+
+@pytest.mark.asyncio
 async def test_number_theory_is_prime(monkeypatch):
     session = StubSession("True")
     await _stub_manager(monkeypatch, session)


### PR DESCRIPTION
Closes #12.

## The bug

`solve_ode` failed on the exact spelling its own docstring documents:

```python
solve_ode(equation="diff(y(x), x) + y(x) = cos(x)", function="y", variable="x")
# TypeError: Substitution using function-call syntax and unnamed arguments has
# been removed. You can use named arguments instead, like EXPR(x=..., y=...)
```

The generated Sage code bound the dependent name to the **applied** expression:

```python
_y = function('y')(_x)      # _y is y(x)
_ode_locals['y'] = _y       # so 'y' resolves to y(x)
```

so `y(x)` in the user's equation evaluated as `(y(x))(x)` — calling a symbolic expression with an unnamed argument, which Sage removed. Hence the error, which had nothing to do with the ODE itself.

## Why the obvious fix is wrong

Simply binding the undefined function instead trades one broken spelling for another. Measured against real Sage:

| Equation form | Before | Naive fix | This PR |
|---|---|---|---|
| `diff(y(x), x) + y(x)` (documented) | **FAIL** | OK | **OK** |
| `diff(y, x) + y` (bare) | OK | **FAIL** | **OK** |

The bare form fails against a function object with `unable to convert y to a symbolic expression`. So the equation is parsed against the undefined function first, falling back to the applied expression — both spellings now work, and neither regresses.

## Tests

All against a real Sage runtime, in `tests/test_integration.py`:

- the exact call from the issue
- the bare spelling, guarding against trading one break for the other
- second order, both spellings
- `==` instead of `=`, which takes the non-split branch of the generated code
- a non-default function and variable (`f`, `t`)
- a separable equation
- both spellings must produce byte-identical solutions

Plus a Sage-free guard in `tests/test_server.py` asserting the generated code binds the function, so a regression is caught by the fast suite too.

**These tests fail against the previous implementation with the exact error from the issue**, verified by stashing the fix and re-running:

```
FAILED tests/test_integration.py::...[diff(y(x), x) + y(x) = cos(x)]
E   SageEvaluationError: Substitution using function-call syntax and unnamed
    arguments has been removed...
2 failed, 1 passed
```

## Verification

| | Result |
|---|---|
| Full integration suite (SageMath 10.9) | **258 passed** |
| Unit suite | **243 passed** |
| `ruff check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA