### PR TITLE
Make plot3d_expression render, and raise the worker stream limit

### DIFF
--- a/src/sagemath_mcp/server.py
+++ b/src/sagemath_mcp/server.py
@@ -327,6 +327,11 @@ async def documentation_resource(scope: str, ctx: Context | None = None) -> list
     return [link for link in DOC_LINKS if link.slug == scope]
 
 
+# Samples per axis for the 3D surface. 48x48 keeps the rendered surface smooth
+# while staying well inside the evaluation timeout.
+_PLOT3D_GRID = 48
+
+
 def _encode_literal(value: str | Iterable) -> str:
     return json.dumps(value)
 
@@ -983,20 +988,52 @@ async def plot3d_expression(
             f"""
         import base64
         import io as _io
+        from sage.plot.graphics import Graphics as _Graphics
         _xv = var({_encode_literal(x_variable)})
         _yv = var({_encode_literal(y_variable)})
         _expr = sage_eval({_encode_literal(expression)}, locals=_locals)
-        _plt = plot3d(_expr, (_xv, {x_range_min}, {x_range_max}),
-                     (_yv, {y_range_min}, {y_range_max}))
+        # Sage's plot3d returns a Graphics3d, whose save()/save_image() require
+        # a filesystem path and reject a BytesIO. There is no .matplotlib()
+        # figure on it either, and a temp file is unreachable from the sandbox
+        # (`open` is forbidden, tempfile/os are not importable). So sample the
+        # surface and render it through matplotlib's 3D axes, which writes to
+        # memory. A 2D Graphics is only used to obtain a Figure without
+        # importing matplotlib directly.
+        try:
+            _f = fast_callable(_expr, vars=(_xv, _yv), domain=float)
+        except Exception:
+            _f = None
+
+        def _z_at(_a, _b):
+            # Singular or complex-valued points become NaN, which matplotlib
+            # renders as a gap rather than failing the whole plot.
+            try:
+                if _f is not None:
+                    return float(_f(_a, _b))
+                return float(_expr.subs({{_xv: _a, _yv: _b}}))
+            except Exception:
+                return float('nan')
+
+        _n = {_PLOT3D_GRID}
+        _xlo, _xhi = float({x_range_min}), float({x_range_max})
+        _ylo, _yhi = float({y_range_min}), float({y_range_max})
+        _gx, _gy, _gz = [], [], []
+        for _i in range(_n):
+            _a = _xlo + (_xhi - _xlo) * _i / (_n - 1)
+            for _j in range(_n):
+                _b = _ylo + (_yhi - _ylo) * _j / (_n - 1)
+                _gx.append(_a)
+                _gy.append(_b)
+                _gz.append(_z_at(_a, _b))
+        _fig = _Graphics().matplotlib()
+        _fig.clf()
+        _ax = _fig.add_subplot(111, projection='3d')
+        # plot_trisurf accepts flat sequences, so no numpy import is needed.
+        _ax.plot_trisurf(_gx, _gy, _gz, cmap='viridis')
+        _ax.set_xlabel({_encode_literal(x_variable)})
+        _ax.set_ylabel({_encode_literal(y_variable)})
         _buf = _io.BytesIO()
-        # NOTE: this is currently broken and has no in-sandbox fix.
-        # Graphics3d.save()/save_image() require a filesystem path and reject a
-        # BytesIO, and unlike 2D Graphics there is no .matplotlib() figure to
-        # render into memory. Writing a temp file is not possible either:
-        # `open` is a forbidden call and `tempfile`/`os` are not in
-        # allowed_import_modules. Fixing this needs either a security-policy
-        # change or rendering outside the sandboxed worker.
-        _plt.save(_buf, format='png')
+        _fig.savefig(_buf, format='png')
         _buf.seek(0)
         base64.b64encode(_buf.read()).decode('ascii')
         """

--- a/src/sagemath_mcp/session.py
+++ b/src/sagemath_mcp/session.py
@@ -19,6 +19,12 @@ from .config import DEFAULT_SETTINGS, SageSettings
 LOGGER = logging.getLogger(__name__)
 _PROJECT_ROOT = str(Path(__file__).resolve().parents[1])
 
+# Buffer for a single JSON response line from the worker. asyncio defaults to
+# 64 KiB, which is smaller than legitimate results such as a base64-encoded
+# plot. 8 MiB leaves generous headroom above the default max_stdout_chars
+# without letting a runaway worker consume unbounded memory.
+_STREAM_LIMIT = 8 * 1024 * 1024
+
 
 class SageProcessError(RuntimeError):
     """Raised when the underlying Sage process terminates unexpectedly."""
@@ -95,6 +101,13 @@ class SageSession:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
+            # One JSON response is read with a single readline(), so the whole
+            # payload must fit in the stream buffer. asyncio's 64 KiB default
+            # raises LimitOverrunError on larger results -- a base64 PNG from
+            # plot3d_expression is around 100 KiB, and matrices or series can
+            # also exceed it. Sized against max_stdout, which already bounds
+            # how much a result may carry.
+            limit=_STREAM_LIMIT,
         )
         self._stderr_task = asyncio.create_task(self._consume_stderr())
         self.started_at = time.time()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -201,3 +201,27 @@ async def test_solve_ode_applied_and_bare_agree(monkeypatch):
         assert str(applied["solution"]) == str(bare["solution"])
     finally:
         await manager.shutdown()
+
+
+@requires_sage
+@pytest.mark.asyncio
+async def test_large_result_exceeds_asyncio_default_stream_limit():
+    """A result larger than asyncio's 64 KiB default must survive the round trip.
+
+    One JSON response is read with a single readline(), so the whole payload
+    has to fit in the subprocess stream buffer. With asyncio's default limit
+    this raised LimitOverrunError, which is what broke plot3d_expression: its
+    base64 PNG is around 100 KiB.
+    """
+
+    settings = SageSettings(force_python_worker=False)
+    session = SageSession("integration-large-result", settings)
+    try:
+        # Comfortably past the 64 KiB default.
+        result = await session.evaluate(
+            "'x' * 200000", want_latex=False, capture_stdout=False
+        )
+        assert result.result is not None
+        assert len(result.result) >= 200000
+    finally:
+        await session.shutdown()

--- a/tests/test_math_examples.py
+++ b/tests/test_math_examples.py
@@ -23,7 +23,7 @@ import pytest
 
 from sagemath_mcp import server
 from sagemath_mcp.config import SageSettings
-from sagemath_mcp.session import SageEvaluationError, SageSessionManager
+from sagemath_mcp.session import SageSessionManager
 
 from .conftest import FakeContext
 
@@ -454,16 +454,28 @@ async def test_documented_examples(monkeypatch, tool):
 
 @requires_sage
 @pytest.mark.asyncio
-async def test_plot3d_expression_cannot_render_in_sandbox(monkeypatch):
-    """plot3d_expression is known broken; this pins the failure until it is fixed.
+@pytest.mark.parametrize(
+    ("label", "expression"),
+    [
+        # doc: 'sin(x)*cos(y)'
+        ("doc:sin*cos", "sin(x)*cos(y)"),
+        ("paraboloid", "x^2 + y^2"),
+        # Singular and partly complex surfaces must render with gaps rather
+        # than failing the whole plot.
+        ("singular at the axes", "1/(x*y)"),
+        ("complex for x < 0", "sqrt(x)"),
+        # Degenerate inputs: no variables, and only one of the two.
+        ("constant", "1"),
+        ("single variable", "x"),
+    ],
+)
+async def test_plot3d_expression_renders_png(monkeypatch, label, expression):
+    """plot3d_expression must return a PNG payload.
 
-    Graphics3d.save()/save_image() require a filesystem path and reject a
-    BytesIO, and unlike 2D Graphics there is no .matplotlib() figure to render
-    into memory. A temp file is not an option either: `open` is a forbidden
-    call and `tempfile`/`os` are not in allowed_import_modules. Fixing this
-    needs a security-policy change or rendering outside the sandboxed worker.
-
-    When that is resolved, replace this with an assertion on the PNG payload.
+    This previously failed for every input: Graphics3d.save()/save_image()
+    require a filesystem path and reject a BytesIO, there is no .matplotlib()
+    figure on a Graphics3d, and a temp file is unreachable from the sandbox.
+    It now samples the surface and renders through matplotlib's 3D axes.
     """
 
     settings = SageSettings(force_python_worker=False, eval_timeout=120.0)
@@ -472,8 +484,11 @@ async def test_plot3d_expression_cannot_render_in_sandbox(monkeypatch):
     ctx = FakeContext("examples-plot3d")
 
     try:
-        with pytest.raises(SageEvaluationError) as excinfo:
-            await S.plot3d_expression("sin(x)*cos(y)", ctx=ctx)
-        assert "os.PathLike" in str(excinfo.value)
+        result = await S.plot3d_expression(expression, ctx=ctx)
+        assert result["format"] == "png"
+        payload = result["image_base64"]
+        # Base64 of the PNG magic bytes.
+        assert payload.startswith("iVBORw0KGgo"), f"{label}: not a PNG payload"
+        assert len(payload) > 1000, f"{label}: payload suspiciously small"
     finally:
         await manager.shutdown()


### PR DESCRIPTION
`plot3d_expression` failed for **every** input. Two independent defects had to be fixed — the second was hidden behind the first.

## 1. Rendering

Sage's `plot3d` returns a `Graphics3d`, whose `save()`/`save_image()` require a filesystem path and reject a `BytesIO`. Unlike a 2D `Graphics` there is no `.matplotlib()` figure to render into memory, and a temp file is unreachable from the sandbox: `open` is a forbidden call and `tempfile`/`os` are not in `allowed_import_modules`.

The surface is now sampled on a 48×48 grid and drawn through matplotlib's 3D axes, obtained from a throwaway 2D `Graphics` so matplotlib never has to be imported directly. `plot_trisurf` accepts flat Python sequences, so no numpy import is needed either.

**This needs no change to the security policy**, which was the alternative I flagged in #18. The sandbox stays exactly as tight as it was.

Singular and complex-valued points become `NaN` and render as gaps rather than failing the whole plot.

## 2. Transport

With rendering fixed, every call *still* failed:

```
asyncio.exceptions.LimitOverrunError: Separator is not found, and chunk exceed the limit
```

A JSON response is read with a single `readline()`, so the payload must fit the subprocess stream buffer — and asyncio defaults to **64 KiB**. A base64 PNG from plot3d is around 100 KiB. Raised to 8 MiB.

This was never specific to plotting. **Any result over 64 KiB failed the same way** — a large matrix, a long series expansion, a big factorisation. It only surfaced now because 2D plots (~20 KiB) sit under the limit and nothing else in the suite produced a payload that large.

## Tests

- `plot3d_expression` over its documented `sin(x)*cos(y)`, plus a paraboloid, a singular surface (`1/(x*y)`), a partly complex surface (`sqrt(x)`), a constant, and a single-variable expression.
- An integration test round-tripping a 200 KB result, which **reproduces `LimitOverrunError` without the transport fix** — verified by reverting `session.py` and re-running.

This also replaces the deliberately-pinned failing test from #18 with real assertions.

| | Result |
|---|---|
| Full integration suite (SageMath 10.9) | **292 passed** (was 286) |
| Unit suite | **243 passed** |
| `ruff check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA