### PR TITLE
Add syntax-variant coverage and fix 3 defects it found

### DIFF
--- a/src/sagemath_mcp/server.py
+++ b/src/sagemath_mcp/server.py
@@ -8,6 +8,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import re
 import textwrap
 from collections.abc import AsyncIterator, Iterable
 from typing import Annotated
@@ -332,8 +333,83 @@ async def documentation_resource(scope: str, ctx: Context | None = None) -> list
 _PLOT3D_GRID = 48
 
 
+def _normalize_source(value):
+    """Collapse whitespace in strings destined for sage_eval.
+
+    Every tool here evaluates its input as a *single* expression, so an
+    embedded newline is a syntax error ("2 +\\n2" fails). Clients are language
+    models, which wrap and indent freely, so runs of whitespace are folded to a
+    single space. evaluate_sage does not pass through here: it takes real
+    multi-line code and keeps its newlines.
+    """
+    if isinstance(value, str):
+        return re.sub(r"\s+", " ", value).strip()
+    if isinstance(value, (list, tuple)):
+        return [_normalize_source(item) for item in value]
+    return value
+
+
 def _encode_literal(value: str | Iterable) -> str:
-    return json.dumps(value)
+    return json.dumps(_normalize_source(value))
+
+
+# Identifiers in a bound or point, e.g. the "a" in an integral up to a.
+_IDENTIFIER_RE = re.compile(r"\b([A-Za-z_]\w*)\b")
+
+# A bare index-style name such as n, k, N or x1.
+_SHORT_NAME_RE = re.compile(r"^[A-Za-z]\d*$")
+
+# Single-letter names that are constants in Sage, not free variables.
+_PROTECTED_CONSTANTS = frozenset({"e", "i", "I"})
+
+# A named graph from Sage's catalogue: "PetersenGraph", "PetersenGraph()" or a
+# parameterised one such as "CompleteGraph(4)".
+_NAMED_GRAPH_RE = re.compile(r"^(?P<name>[A-Za-z_]\w*)\s*(?P<call>\(.*\))?$", re.DOTALL)
+
+
+def _declare_free_symbols(*sources: str | None) -> str:
+    """Code that declares any unknown identifier in *sources* as a symbol.
+
+    A bound may legitimately be symbolic -- integrating to "a", or summing to
+    "n" -- but the prelude only declares x, y, z, t plus the tool's own
+    variable, so anything else raised "name 'a' is not defined".
+
+    Names Sage already defines are left alone. Declaring them would shadow the
+    real object and break the very inputs that do work today: var('oo') would
+    turn infinity into an ordinary symbol, and the same applies to pi, e, I and
+    every function name such as sin or sqrt.
+    """
+    names: set[str] = set()
+    for source in sources:
+        if source:
+            names.update(_IDENTIFIER_RE.findall(source))
+    if not names:
+        return ""
+    # Short names win over anything Sage happens to define, because Sage's
+    # namespace collides with ordinary index names: "n" and "N" are
+    # numerical_approx, so summing to n resolved the bound to a function rather
+    # than a symbol. The true constants are the exception and must never be
+    # shadowed -- e is Euler's number, and i and I are the imaginary unit.
+    forced = sorted(
+        name for name in names if _SHORT_NAME_RE.match(name) and name not in _PROTECTED_CONSTANTS
+    )
+    # Longer names keep the conservative check, so sin, sqrt, pi, oo, gamma and
+    # every other spelled-out Sage object continues to mean what it says.
+    conditional = sorted(names.difference(forced))
+
+    # Emitted as a single physical line. These snippets are interpolated into
+    # templates that are then passed through textwrap.dedent, and a multi-line
+    # block would arrive unindented, destroying the common prefix dedent relies
+    # on ("unexpected indent" at import time).
+    parts = ["import sage.all as _sage_ns"]
+    if forced:
+        parts.append(f"_locals.update({{_n: var(_n) for _n in {forced!r} if _n not in _locals}})")
+    if conditional:
+        parts.append(
+            f"_locals.update({{_n: var(_n) for _n in {conditional!r} "
+            "if _n not in _locals and not hasattr(_sage_ns, _n)})"
+        )
+    return "; ".join(parts)
 
 
 def _normal_parameters(parameters: list[float]) -> tuple[float, float]:
@@ -569,6 +645,7 @@ async def integrate_expression(
                 f"""
             _var = var({_encode_literal(variable)})
             _expr = sage_eval({_encode_literal(expression)}, locals=_locals)
+            {_declare_free_symbols(lower_bound, upper_bound)}
             _lb = sage_eval({_encode_literal(lower_bound)}, locals=_locals)
             _ub = sage_eval({_encode_literal(upper_bound)}, locals=_locals)
             str(integrate(_expr, _var, _lb, _ub))
@@ -732,6 +809,7 @@ async def limit_expression(
             f"""
         _var = var({_encode_literal(variable)})
         _expr = sage_eval({_encode_literal(expression)}, locals=_locals)
+        {_declare_free_symbols(point)}
         _point = sage_eval({_encode_literal(point)}, locals=_locals)
         str(limit(_expr, _var, _point{dir_arg}))
         """
@@ -758,6 +836,7 @@ async def series_expansion(
             f"""
         _var = var({_encode_literal(variable)})
         _expr = sage_eval({_encode_literal(expression)}, locals=_locals)
+        {_declare_free_symbols(point)}
         _point = sage_eval({_encode_literal(point)}, locals=_locals)
         str(_expr.series(_var == _point, {order}))
         """
@@ -919,6 +998,7 @@ async def symbolic_sum(
             f"""
         _var = var({_encode_literal(variable)})
         _expr = sage_eval({_encode_literal(expression)}, locals=_locals)
+        {_declare_free_symbols(lower, upper)}
         _lo = sage_eval({_encode_literal(lower)}, locals=_locals)
         _hi = sage_eval({_encode_literal(upper)}, locals=_locals)
         str({op}(_expr, _var, _lo, _hi))
@@ -1373,11 +1453,17 @@ async def graph_operation(
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required")
     session = await SESSION_MANAGER.get(ctx.session_id)
-    # Determine graph construction
-    if graph.endswith("Graph") or graph.endswith("Graph()"):
-        g_name = graph.rstrip("()")
-        graph_code = f"_G = graphs.{g_name}()"
+    # A named graph is an identifier, optionally already called with arguments.
+    # Matching on a "Graph" suffix missed every parameterised constructor:
+    # "CompleteGraph(4)" ends in ")", so it fell through to Graph(CompleteGraph(4))
+    # and failed with "name 'CompleteGraph' is not defined". Most named graphs
+    # take parameters, so that was the majority of the catalogue.
+    named = _NAMED_GRAPH_RE.match(graph.strip())
+    if named:
+        call = named.group("call") or "()"
+        graph_code = f"_G = graphs.{named.group('name')}{call}"
     else:
+        # Anything else is a literal, such as an adjacency dict.
         graph_code = f"_G = Graph({graph})"
     ops = {
         "chromatic_number": "int(_G.chromatic_number())",

--- a/tests/test_generated_code_lint.py
+++ b/tests/test_generated_code_lint.py
@@ -1,0 +1,176 @@
+"""Static checks over the Sage code that server.py generates.
+
+These run without a Sage runtime, so they execute in the fast unit job and
+catch whole bug classes in milliseconds rather than waiting for the integration
+job to evaluate anything.
+
+Each check corresponds to a defect that actually shipped:
+
+* ``^`` in a generated template that is executed as Python, where it means XOR
+  rather than exponentiation. geometry_operation computed the 3-4-5 triangle
+  distance as sqrt(-3).
+* ``save(_buf)`` on a Sage graphics object, which requires a filesystem path
+  and rejects a BytesIO. All three plot tools were non-functional.
+* A documented example that no test exercises, which is how issue #12 survived:
+  ``solve_ode`` rejected the exact input its own docstring advertised.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+SERVER_PATH = Path(__file__).resolve().parents[1] / "src" / "sagemath_mcp" / "server.py"
+TESTS_DIR = Path(__file__).resolve().parent
+
+
+@pytest.fixture(scope="module")
+def server_source() -> str:
+    return SERVER_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def server_tree(server_source: str) -> ast.Module:
+    return ast.parse(server_source)
+
+
+def _field_description_strings(tree: ast.Module) -> list[str]:
+    """Every string that makes up a Field(description=...) value.
+
+    Descriptions are frequently split across implicitly concatenated literals,
+    so each piece is collected individually.
+    """
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and getattr(node.func, "id", None) == "Field"):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg != "description":
+                continue
+            for sub in ast.walk(keyword.value):
+                if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                    found.append(sub.value)
+    return found
+
+
+def _non_code_strings(tree: ast.Module) -> set[str]:
+    """Strings where a ``^`` is legitimate and is not generated Python.
+
+    Three sources: tool and parameter documentation, which quotes Sage syntax;
+    regular expressions, where ``^`` anchors rather than XORs; and docstrings.
+    """
+    excluded = set(_field_description_strings(tree))
+
+    for node in ast.walk(tree):
+        # description= on @mcp.tool(...) as well as on Field(...)
+        if isinstance(node, ast.Call):
+            func = node.func
+            is_compile = isinstance(func, ast.Attribute) and func.attr == "compile"
+            for keyword in node.keywords:
+                if keyword.arg == "description":
+                    for sub in ast.walk(keyword.value):
+                        if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                            excluded.add(sub.value)
+            if is_compile:
+                for arg in node.args:
+                    for sub in ast.walk(arg):
+                        if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                            excluded.add(sub.value)
+        # Docstrings describe behaviour; they are never executed.
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc:
+                excluded.add(doc)
+    return excluded
+
+
+def test_no_caret_in_generated_python(server_tree: ast.Module) -> None:
+    """``^`` must not appear in generated code outside documentation.
+
+    User expressions are safe because they go through sage_eval, whose
+    preparser turns ``^`` into exponentiation. Code the server builds itself is
+    executed as plain Python, where ``^`` is XOR and silently produces a wrong
+    number instead of an error.
+    """
+    documentation = _non_code_strings(server_tree)
+
+    offenders: list[str] = []
+    for node in ast.walk(server_tree):
+        if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
+            continue
+        text = node.value
+        if "^" not in text or text in documentation:
+            continue
+        offenders.append(f"line {node.lineno}: {text.strip()[:90]!r}")
+
+    assert not offenders, (
+        "'^' means XOR in generated Python, not exponentiation. Use '**', or "
+        "route the expression through sage_eval:\n" + "\n".join(f"  - {o}" for o in offenders)
+    )
+
+
+def test_no_sage_save_to_buffer(server_source: str) -> None:
+    """Sage's save() needs a path and rejects a BytesIO.
+
+    2D graphics render in memory via .matplotlib().savefig(); 3D is sampled and
+    drawn through matplotlib's 3D axes. Neither may call save() on a buffer.
+    """
+    offenders = [
+        f"line {number}: {line.strip()[:90]}"
+        for number, line in enumerate(server_source.splitlines(), start=1)
+        if re.search(r"(?<!fig)\.save\(\s*_buf", line)
+    ]
+    assert not offenders, (
+        "Sage save() requires a filesystem path and raises "
+        "'expected str, bytes or os.PathLike object' for a BytesIO. Render "
+        "through matplotlib instead:\n" + "\n".join(f"  - {o}" for o in offenders)
+    )
+
+
+# Fragments that look like examples but are prose, enum listings, or values
+# whose spelling is not what a caller passes.
+_NOT_AN_EXAMPLE = re.compile(
+    r"^(?:[\w ]+:|One of|Operation|Distribution name|Code constructor|Base ring|"
+    r"Variable names|Polynomials|Sage group constructor|Graph constructor)",
+)
+
+
+def _documented_examples(tree: ast.Module) -> set[str]:
+    """Quoted example values embedded in Field descriptions."""
+    examples: set[str] = set()
+    for text in _field_description_strings(tree):
+        if not re.search(r"e\.g\.|like", text):
+            continue
+        # Quoted fragments are the examples: 'x^2 - 1 = 0', 'PetersenGraph', ...
+        for quoted in re.findall(r"'([^']{2,})'", text):
+            if _NOT_AN_EXAMPLE.match(quoted):
+                continue
+            examples.add(quoted.strip())
+    return examples
+
+
+def test_every_documented_example_is_exercised(server_tree: ast.Module) -> None:
+    """Anything the tools advertise must appear in a test.
+
+    This is the guard that makes issue #12 structurally impossible. #12 was a
+    documented spelling that had never been executed by a test, and the
+    documented-example suite then found six more of the same kind. Enforcing
+    the link mechanically beats relying on reviewer diligence.
+    """
+    examples = _documented_examples(server_tree)
+    assert examples, "no documented examples were extracted; the parser has drifted"
+
+    corpus = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted(TESTS_DIR.glob("test_*.py"))
+    )
+
+    missing = sorted(example for example in examples if example not in corpus)
+    assert not missing, (
+        "These examples are advertised in a tool's Field description but never "
+        "exercised by a test. Add a case, or stop documenting the spelling:\n"
+        + "\n".join(f"  - {example!r}" for example in missing)
+    )

--- a/tests/test_math_examples.py
+++ b/tests/test_math_examples.py
@@ -301,6 +301,12 @@ GROUPS: dict[str, list] = {
          "result", 5),
         ("C6 exponent is 6",
          lambda c: S.group_operation("CyclicPermutationGroup(6)", "exponent", ctx=c), "result", 6),
+        # doc: 'AlternatingGroup(5)' -- order 5!/2, and the smallest
+        # non-abelian simple group, so its centre is trivial.
+        ("doc:A5 order is 60",
+         lambda c: S.group_operation("AlternatingGroup(5)", "order", ctx=c), "result", 60),
+        ("A5 is not abelian",
+         lambda c: S.group_operation("AlternatingGroup(5)", "is_abelian", ctx=c), "result", False),
     ],
     "elliptic_curve_operation": [
         # doc: short Weierstrass [a, b] for y^2 = x^3 + a*x + b

--- a/tests/test_syntax_variants.py
+++ b/tests/test_syntax_variants.py
@@ -1,0 +1,296 @@
+"""Systematic coverage of the input spellings each tool must accept.
+
+`test_math_examples.py` covers one spelling per tool: the documented one.
+Clients are language models, which emit many spellings of the same request, and
+every defect found so far has lived in that gap -- a tool embedding a string
+into generated Sage or Python where valid input stops being valid.
+
+Variants are organised by *parameter kind* rather than by tool. There are ~9
+kinds across 30 tools, so one variant set covers every tool sharing a kind.
+
+Three complementary checks:
+
+* EQUIVALENCE -- spellings that mean the same thing must produce the same
+  answer. This is the strongest check available: it needs no hardcoded expected
+  value and it catches silently-wrong results, not just exceptions. "2^10" and
+  "2**10" disagreeing is a bug whichever one is right.
+* ACCEPTED -- valid input that must work, with a predicate on the value.
+* REJECTED -- invalid input that must fail cleanly. Clients retry on error, so
+  a clear failure is a usable outcome; a wrong number is not.
+"""
+
+import shutil
+
+import pytest
+
+from sagemath_mcp import server
+from sagemath_mcp.config import SageSettings
+from sagemath_mcp.session import SageSessionManager
+
+from .conftest import FakeContext
+
+requires_sage = pytest.mark.skipif(
+    shutil.which("sage") is None, reason="Sage executable not available"
+)
+
+S = server
+
+
+@pytest.fixture(autouse=True)
+def unset_pure_python(monkeypatch):
+    monkeypatch.delenv("SAGEMATH_MCP_PURE_PYTHON", raising=False)
+
+
+# --------------------------------------------------------------------------
+# Equivalence classes: {group: (result key, [(label, call), ...])}
+# Every spelling in a group must yield the same value for that key.
+# --------------------------------------------------------------------------
+EQUIVALENCE: dict[str, tuple[str, list]] = {
+    "expression: power operator": ("string", [
+        # Sage's preparser turns ^ into exponentiation. In generated code that
+        # is executed as plain Python it would mean XOR instead, which is how
+        # geometry_operation once computed a complex distance for a 3-4-5
+        # triangle. Both spellings must agree.
+        ("caret", lambda c: S.calculate_expression("2^10", ctx=c)),
+        ("double star", lambda c: S.calculate_expression("2**10", ctx=c)),
+    ]),
+    "expression: whitespace": ("string", [
+        ("compact", lambda c: S.calculate_expression("2+2", ctx=c)),
+        ("spaced", lambda c: S.calculate_expression("  2  +  2  ", ctx=c)),
+        # Models wrap and indent freely, so a newline must not be a syntax error.
+        ("newline", lambda c: S.calculate_expression("2 +\n2", ctx=c)),
+        ("tab", lambda c: S.calculate_expression("2\t+\t2", ctx=c)),
+    ]),
+    "expression: unicode constant": ("string", [
+        ("ascii", lambda c: S.calculate_expression("pi.n()", ctx=c)),
+        ("unicode", lambda c: S.calculate_expression("π.n()", ctx=c)),
+    ]),
+    "equation: equality spelling": ("solutions", [
+        ("single equals", lambda c: S.solve_equation("x^2 - 1 = 0", "x", ctx=c)),
+        ("double equals", lambda c: S.solve_equation("x^2 - 1 == 0", "x", ctx=c)),
+        ("implicit zero", lambda c: S.solve_equation("x^2 - 1", "x", ctx=c)),
+        ("sides reversed", lambda c: S.solve_equation("0 = x^2 - 1", "x", ctx=c)),
+    ]),
+    "equation: variable container": ("solutions", [
+        ("string", lambda c: S.solve_equation("x^2 - 1 = 0", "x", ctx=c)),
+        ("list", lambda c: S.solve_equation("x^2 - 1 = 0", ["x"], ctx=c)),
+    ]),
+    "equation: single equation container": ("solutions", [
+        ("bare", lambda c: S.solve_equation("x^2 - 1 = 0", "x", ctx=c)),
+        ("wrapped in list", lambda c: S.solve_equation(["x^2 - 1 = 0"], "x", ctx=c)),
+    ]),
+    "ode: function application": ("solution", [
+        # The #12 regression, kept here so it is covered by the syntax matrix
+        # as well as by its own dedicated test.
+        ("applied y(x)", lambda c: S.solve_ode("diff(y(x), x) + y(x) = 0", ctx=c)),
+        ("bare y", lambda c: S.solve_ode("diff(y, x) + y = 0", ctx=c)),
+    ]),
+    "bound: infinity spelling": ("limit", [
+        ("oo", lambda c: S.limit_expression("1/x", "x", "oo", ctx=c)),
+        ("plus oo", lambda c: S.limit_expression("1/x", "x", "+oo", ctx=c)),
+        ("infinity", lambda c: S.limit_expression("1/x", "x", "infinity", ctx=c)),
+        ("Infinity", lambda c: S.limit_expression("1/x", "x", "Infinity", ctx=c)),
+    ]),
+    "bound: numeric spelling": ("integral", [
+        ("integer", lambda c: S.integrate_expression(
+            "x^2", "x", lower_bound="0", upper_bound="1", ctx=c)),
+        ("decimal", lambda c: S.integrate_expression(
+            "x^2", "x", lower_bound="0.0", upper_bound="1.0", ctx=c)),
+        ("rational", lambda c: S.integrate_expression(
+            "x^2", "x", lower_bound="0", upper_bound="2/2", ctx=c)),
+    ]),
+    "matrix: entry types": ("result", [
+        ("integers", lambda c: S.matrix_operation([[1, 2], [3, 4]], "determinant", ctx=c)),
+        ("floats", lambda c: S.matrix_operation([[1.0, 2.0], [3.0, 4.0]], "determinant", ctx=c)),
+    ]),
+    "constructor: named graph spelling": ("result", [
+        ("bare name", lambda c: S.graph_operation("PetersenGraph", "order", ctx=c)),
+        ("explicit call", lambda c: S.graph_operation("PetersenGraph()", "order", ctx=c)),
+        ("padded", lambda c: S.graph_operation("  PetersenGraph  ", "order", ctx=c)),
+    ]),
+    "boolean: variable spelling": ("result", [
+        ("documented x,y,z", lambda c: S.boolean_algebra_operation(
+            "x*y + x*z + y*z", "degree", num_variables=3, ctx=c)),
+        ("generator x0,x1,x2", lambda c: S.boolean_algebra_operation(
+            "x0*x1 + x0*x2 + x1*x2", "degree", num_variables=3, ctx=c)),
+    ]),
+}
+
+
+# --------------------------------------------------------------------------
+# Valid input that must be accepted, with a predicate on the result.
+# --------------------------------------------------------------------------
+ACCEPTED: dict[str, list] = {
+    "bound: symbolic": [
+        # An integral to a symbolic limit is ordinary calculus. The prelude
+        # declares only x, y, z, t, so anything else used to raise NameError.
+        ("integrate to a", lambda c: S.integrate_expression(
+            "x", "x", lower_bound="0", upper_bound="a", ctx=c), "integral", "1/2*a^2"),
+        ("limit at a", lambda c: S.limit_expression("x^2", "x", "a", ctx=c), "limit", "a^2"),
+        # n and N are numerical_approx in Sage's namespace; as a summation
+        # bound they must still be treated as free symbols.
+        ("sum to n", lambda c: S.symbolic_sum("k", "k", "1", "n", ctx=c),
+         "result", "1/2*n^2 + 1/2*n"),
+        ("sum to N", lambda c: S.symbolic_sum("k", "k", "1", "N", ctx=c),
+         "result", "1/2*N^2 + 1/2*N"),
+    ],
+    "bound: constants must not be shadowed": [
+        # The mirror of the case above: these names must keep their Sage
+        # meaning. Declaring them as symbols would silently change the answer.
+        ("integrate to e is ln(e) = 1", lambda c: S.integrate_expression(
+            "1/x", "x", lower_bound="1", upper_bound="e", ctx=c), "integral", "1"),
+        ("integrate sin to pi is 2", lambda c: S.integrate_expression(
+            "sin(x)", "x", lower_bound="0", upper_bound="pi", ctx=c), "integral", "2"),
+        ("integrate cos to pi/2 is 1", lambda c: S.integrate_expression(
+            "cos(x)", "x", lower_bound="0", upper_bound="pi/2", ctx=c), "integral", "1"),
+        ("sum to oo is basel", lambda c: S.symbolic_sum("1/n^2", "n", "1", "oo", ctx=c),
+         "result", "1/6*pi^2"),
+    ],
+    "constructor: parameterised graphs": [
+        # Matching on a "Graph" suffix rejected every constructor taking
+        # arguments, which is most of Sage's catalogue.
+        ("CompleteGraph(4) order", lambda c: S.graph_operation(
+            "CompleteGraph(4)", "order", ctx=c), "result", 4),
+        ("CompleteGraph(4) size", lambda c: S.graph_operation(
+            "CompleteGraph(4)", "size", ctx=c), "result", 6),
+        ("CycleGraph(6) size", lambda c: S.graph_operation(
+            "CycleGraph(6)", "size", ctx=c), "result", 6),
+        ("CompleteBipartiteGraph(2,3)", lambda c: S.graph_operation(
+            "CompleteBipartiteGraph(2,3)", "order", ctx=c), "result", 5),
+        ("adjacency dict still works", lambda c: S.graph_operation(
+            "{0:[1,2], 1:[0,2], 2:[0,1]}", "order", ctx=c), "result", 3),
+    ],
+    "variable: naming": [
+        ("multi-character name", lambda c: S.differentiate_expression(
+            "t1^2", "t1", ctx=c), "derivative", "2*t1"),
+        ("greek word name", lambda c: S.differentiate_expression(
+            "alpha^3", "alpha", ctx=c), "derivative", "3*alpha^2"),
+        ("non-default variable", lambda c: S.integrate_expression(
+            "u^2", "u", ctx=c), "integral", "1/3*u^3"),
+    ],
+    "expression: numeric literals": [
+        ("rational stays exact", lambda c: S.calculate_expression("1/3", ctx=c),
+         "string", "1/3"),
+        ("unary minus", lambda c: S.calculate_expression("-2^2", ctx=c), "string", "-4"),
+        ("nested parentheses", lambda c: S.expand_expression("((x+1)*(x-1))", ctx=c),
+         "expanded", "x^2 - 1"),
+        ("scientific notation", lambda c: S.calculate_expression("1e3", ctx=c),
+         "numeric", 1000.0),
+    ],
+}
+
+
+# --------------------------------------------------------------------------
+# Invalid input that must fail cleanly rather than return a wrong answer.
+# --------------------------------------------------------------------------
+REJECTED: list = [
+    # Sage does not support implicit multiplication either; the contract is
+    # that it fails rather than silently parsing as something else.
+    ("implicit multiplication", lambda c: S.differentiate_expression("2x", "x", ctx=c)),
+    ("latex input", lambda c: S.calculate_expression(r"\sqrt{4}", ctx=c)),
+    ("wrong case function", lambda c: S.calculate_expression("Sin(0)", ctx=c)),
+    ("unbalanced parenthesis", lambda c: S.calculate_expression("(2+3", ctx=c)),
+    ("unknown matrix operation", lambda c: S.matrix_operation([[1]], "nonsense", ctx=c)),
+    ("unknown graph operation", lambda c: S.graph_operation("PetersenGraph", "nonsense", ctx=c)),
+    ("unknown distribution", lambda c: S.distribution_operation("nonsense", [1], "mean", ctx=c)),
+]
+
+
+@requires_sage
+@pytest.mark.asyncio
+@pytest.mark.parametrize("group", sorted(EQUIVALENCE), ids=sorted(EQUIVALENCE))
+async def test_equivalent_spellings_agree(monkeypatch, group):
+    """Spellings that mean the same thing must produce the same answer."""
+
+    key, cases = EQUIVALENCE[group]
+    settings = SageSettings(force_python_worker=False, eval_timeout=120.0)
+    manager = SageSessionManager(settings)
+    monkeypatch.setattr(server, "SESSION_MANAGER", manager)
+
+    observed: dict[str, object] = {}
+    failures: list[str] = []
+    try:
+        for label, factory in cases:
+            ctx = FakeContext(f"variants-{group}")
+            try:
+                result = await factory(ctx)
+            except Exception as exc:
+                failures.append(f"{label}: raised {type(exc).__name__}: {exc}")
+                continue
+            if key not in result:
+                failures.append(f"{label}: result has no key {key!r}; got {result!r}")
+                continue
+            observed[label] = result[key]
+    finally:
+        await manager.shutdown()
+
+    assert not failures, f"{group}:\n" + "\n".join(f"  - {f}" for f in failures)
+    distinct = {repr(v) for v in observed.values()}
+    assert len(distinct) == 1, (
+        f"{group}: spellings disagree, but they describe the same value\n"
+        + "\n".join(f"  - {label} -> {value!r}" for label, value in observed.items())
+    )
+
+
+@requires_sage
+@pytest.mark.asyncio
+@pytest.mark.parametrize("group", sorted(ACCEPTED), ids=sorted(ACCEPTED))
+async def test_valid_spellings_are_accepted(monkeypatch, group):
+    """Valid input must be accepted and produce the right value."""
+
+    settings = SageSettings(force_python_worker=False, eval_timeout=120.0)
+    manager = SageSessionManager(settings)
+    monkeypatch.setattr(server, "SESSION_MANAGER", manager)
+
+    failures: list[str] = []
+    try:
+        for label, factory, key, expected in ACCEPTED[group]:
+            ctx = FakeContext(f"variants-{group}")
+            try:
+                result = await factory(ctx)
+            except Exception as exc:
+                failures.append(f"{label}: raised {type(exc).__name__}: {exc}")
+                continue
+            actual = result.get(key)
+            if isinstance(expected, float):
+                ok = actual is not None and abs(float(actual) - expected) < 1e-9
+            else:
+                ok = actual == expected
+            if not ok:
+                failures.append(f"{label}: expected {expected!r}, got {actual!r}")
+    finally:
+        await manager.shutdown()
+
+    assert not failures, f"{group}:\n" + "\n".join(f"  - {f}" for f in failures)
+
+
+@requires_sage
+@pytest.mark.asyncio
+async def test_invalid_input_fails_cleanly(monkeypatch):
+    """Invalid input must raise with a usable message, never return a value.
+
+    Returning a wrong number here would be the worst outcome: the client has no
+    way to tell it apart from a correct one. An error is recoverable, because
+    the caller can correct the request and retry.
+    """
+
+    settings = SageSettings(force_python_worker=False, eval_timeout=120.0)
+    manager = SageSessionManager(settings)
+    monkeypatch.setattr(server, "SESSION_MANAGER", manager)
+
+    failures: list[str] = []
+    try:
+        for label, factory in REJECTED:
+            ctx = FakeContext("variants-invalid")
+            try:
+                result = await factory(ctx)
+            except Exception as exc:
+                message = str(exc).strip()
+                if not message:
+                    failures.append(f"{label}: raised {type(exc).__name__} with an empty message")
+                continue
+            failures.append(f"{label}: accepted invalid input and returned {result!r}")
+    finally:
+        await manager.shutdown()
+
+    assert not failures, "invalid input handling:\n" + "\n".join(f"  - {f}" for f in failures)


### PR DESCRIPTION
Replaces #20, which GitHub auto-closed when its base branch (`fix/plot3d-inmemory-render`, from #19) was deleted on merge. Same content, rebased directly onto `main`.

`test_math_examples.py` covers **one spelling per tool**: the documented one. Clients are language models, which emit many spellings of the same request, and every defect found so far has lived in that gap.

## The organising idea

Variants are enumerated **per parameter kind, not per tool**. 30 tools × N variants is intractable; there are only ~9 kinds (expression, equation, variable name, bound, numeric range, nested list, constructor string, operation enum, list param), and one variant set covers every tool sharing a kind.

`tests/test_syntax_variants.py` applies three checks:

- **Equivalence** — spellings that mean the same thing must produce the same answer. No hardcoded expected value needed, and it catches *silently wrong* results rather than only exceptions. `2^10` and `2**10` disagreeing is a bug whichever is right.
- **Accepted** — valid input must work, asserted on the value.
- **Rejected** — invalid input must fail cleanly. Clients retry on error, so a clear failure is recoverable; a wrong number is not.

## Static checks that need no Sage

`tests/test_generated_code_lint.py` runs in the fast unit job. Each check mirrors a defect that actually shipped:

| Check | Defect it would have caught |
|---|---|
| `^` in generated Python | geometry computed the 3-4-5 triangle as `sqrt(-3)` — XOR, not exponentiation |
| `save()` to a `BytesIO` | all three plot tools were non-functional |
| Documented example with no test | **issue #12 itself** |

The third makes #12 structurally impossible: if a spelling is advertised, it is tested — enforced mechanically rather than by reviewer diligence. It immediately found `AlternatingGroup(5)`, documented but never exercised; a case was added rather than the documentation removed.

## Three defects found and fixed

**A. Bounds could not be symbolic.** `integrate`/`limit`/`series`/`symbolic_sum` resolve bounds against a prelude declaring only `x, y, z, t`, so integrating to `a` or summing to `n` raised `NameError`. Unknown identifiers are now declared as symbols.

This one has a sharp edge: **`n` and `N` are `numerical_approx` in Sage**, so summing to `n` resolved the bound to a *function*. Short names therefore win over Sage's namespace — but `e`, `i` and `I` are protected, so the constants keep their meaning. Both directions are tested: `∫₁^e dx/x = 1` and `Σk to n = 1/2*n² + 1/2*n`.

**B. Parameterised graph constructors failed.** The check matched a `"Graph"` suffix, so `"CompleteGraph(4)"` ends in `)` and fell through to `Graph(CompleteGraph(4))` → `name 'CompleteGraph' is not defined`. That is most of Sage's catalogue.

**C. A newline in an expression was a syntax error.** These tools evaluate a *single* expression, and models wrap and indent freely. Whitespace is folded before embedding. `evaluate_sage` is unaffected and keeps its newlines.

## Verification

- The syntax suite **fails on 4 groups without A/B/C**, verified by stashing `server.py`.
- Each static check **fails when its defect is reintroduced**, verified by re-inserting `^2` and `save(_buf)`.

| | Result |
|---|---|
| Integration suite (SageMath 10.9) | **313 passed in 60s** (was 292) |
| Unit suite | **246 passed** (was 243) |
| Runtime budget | 60s against the agreed 180s ceiling |
| `ruff check` | clean |

One deliberate deviation from the plan: no hard wall-clock assertion on suite duration — on shared CI runners that is a flake generator. The budget is documented and observable from job timing instead.

## Confirmed working (no change needed)

Probing found these already correct, so no code was touched: `^` vs `**` across all tools (user expressions route through `sage_eval`, which preparses — the geometry bug was in *generated* code), `oo`/`+oo`/`infinity`/`Infinity`, unicode `π`, `=`/`==`/implicit-zero equations, variable as `str` vs `list`, int vs float matrices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA