### PR TITLE
Complete the syntax-variant matrix and fix 5 more defects

### DIFF
--- a/src/sagemath_mcp/server.py
+++ b/src/sagemath_mcp/server.py
@@ -412,6 +412,24 @@ def _declare_free_symbols(*sources: str | None) -> str:
     return "; ".join(parts)
 
 
+def _check_matrix(rows: list[list[float]], name: str) -> None:
+    """Reject shapes Sage would only complain about obscurely, or not at all.
+
+    An empty matrix is the dangerous one: Sage treats [] as the 0x0 matrix and
+    reports its determinant as 1.0, which looks like a real answer.
+    """
+    if not rows or not all(isinstance(row, (list, tuple)) for row in rows):
+        raise ToolError(f"'{name}' must be a non-empty list of rows")
+    if not rows[0]:
+        raise ToolError(f"'{name}' rows must be non-empty")
+    width = len(rows[0])
+    if any(len(row) != width for row in rows):
+        widths = sorted({len(row) for row in rows})
+        raise ToolError(
+            f"'{name}' rows must all have the same length; found lengths {widths}"
+        )
+
+
 def _normal_parameters(parameters: list[float]) -> tuple[float, float]:
     """Return (mu, sigma) for the documented [mu, sigma] parameter list."""
     if len(parameters) >= 2:
@@ -674,6 +692,10 @@ async def statistics_summary(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required for stateful execution")
+    # Without this the generated code raised a bare "list index out of range"
+    # from the median calculation, which says nothing about what to send instead.
+    if not data:
+        raise ToolError("statistics_summary requires at least one value in 'data'")
     session = await SESSION_MANAGER.get(ctx.session_id)
     code = (
         _sage_prelude()
@@ -711,6 +733,17 @@ async def matrix_multiply(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required for stateful execution")
+    # Checked here so a shape mismatch reports the shapes. Left to Sage it
+    # surfaced as "unsupported operand parent(s) for *: 'Full MatrixSpace of
+    # ...'", which does not say which dimension is wrong.
+    _check_matrix(matrix_a, "matrix_a")
+    _check_matrix(matrix_b, "matrix_b")
+    if len(matrix_a[0]) != len(matrix_b):
+        raise ToolError(
+            f"Cannot multiply a {len(matrix_a)}x{len(matrix_a[0])} matrix by a "
+            f"{len(matrix_b)}x{len(matrix_b[0])} matrix: the number of columns in "
+            "matrix_a must equal the number of rows in matrix_b"
+        )
     session = await SESSION_MANAGER.get(ctx.session_id)
     code = textwrap.dedent(
         f"""
@@ -859,6 +892,8 @@ async def matrix_operation(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required for stateful execution")
+    operation = operation.strip()
+    _check_matrix(matrix, "matrix")
     allowed_ops = {"determinant", "inverse", "eigenvalues", "rank", "rref", "transpose"}
     if operation not in allowed_ops:
         raise ToolError(
@@ -956,6 +991,7 @@ async def number_theory_operation(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required for stateful execution")
+    operation = operation.strip()
     allowed_ops = {"is_prime", "factor_integer", "next_prime", "gcd", "lcm"}
     if operation not in allowed_ops:
         raise ToolError(
@@ -1026,6 +1062,7 @@ async def combinatorics_operation(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required for stateful execution")
+    operation = operation.strip()
     session = await SESSION_MANAGER.get(ctx.session_id)
     op_code = {
         "binomial": f"int(binomial({n}, {k or 0}))",
@@ -1146,6 +1183,7 @@ async def distribution_operation(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required for stateful execution")
+    operation = operation.strip()
     session = await SESSION_MANAGER.get(ctx.session_id)
     params_str = ", ".join(str(p) for p in parameters)
     # "normal" takes [mu, sigma]. The previous mapping passed parameters[0] as
@@ -1308,6 +1346,7 @@ async def vector_calculus_operation(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required for stateful execution")
+    operation = operation.strip()
     if variables is None:
         variables = ["x", "y", "z"]
     session = await SESSION_MANAGER.get(ctx.session_id)
@@ -1452,6 +1491,7 @@ async def graph_operation(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required")
+    operation = operation.strip()
     session = await SESSION_MANAGER.get(ctx.session_id)
     # A named graph is an identifier, optionally already called with arguments.
     # Matching on a "Graph" suffix missed every parameterised constructor:
@@ -1517,6 +1557,7 @@ async def group_operation(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required")
+    operation = operation.strip()
     session = await SESSION_MANAGER.get(ctx.session_id)
     ops = {
         "order": "int(_G.order())",
@@ -1561,6 +1602,7 @@ async def elliptic_curve_operation(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required")
+    operation = operation.strip()
     session = await SESSION_MANAGER.get(ctx.session_id)
     ops = {
         "rank": "int(_E.rank())",
@@ -1611,6 +1653,7 @@ async def coding_theory_operation(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required")
+    operation = operation.strip()
     session = await SESSION_MANAGER.get(ctx.session_id)
     ops = {
         "length": "int(_C.length())",
@@ -1660,6 +1703,7 @@ async def boolean_algebra_operation(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required")
+    operation = operation.strip()
     session = await SESSION_MANAGER.get(ctx.session_id)
     var_names = ", ".join(f"'x{i}'" for i in range(num_variables))
     # The ring generators are x0, x1, ..., but the documented example uses
@@ -1717,6 +1761,7 @@ async def polynomial_ring_operation(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required")
+    operation = operation.strip()
     session = await SESSION_MANAGER.get(ctx.session_id)
     var_list = ", ".join(ring_vars)
     ops = {
@@ -1771,6 +1816,15 @@ async def geometry_operation(
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required")
+    operation = operation.strip()
+    if not points:
+        raise ToolError("'points' must contain at least one point")
+    # distance previously generated the literal "None" for a single point, so
+    # the tool returned {'result': None} as though that were an answer.
+    if operation == "distance" and len(points) < 2:
+        raise ToolError(
+            f"Operation 'distance' requires two points, got {len(points)}"
+        )
     session = await SESSION_MANAGER.get(ctx.session_id)
     pts = _encode_literal(points)
     ops = {

--- a/tests/test_syntax_variants.py
+++ b/tests/test_syntax_variants.py
@@ -41,6 +41,11 @@ def unset_pure_python(monkeypatch):
     monkeypatch.delenv("SAGEMATH_MCP_PURE_PYTHON", raising=False)
 
 
+def _is_png(value) -> bool:
+    """Base64 of the PNG magic bytes, with enough payload to be a real image."""
+    return isinstance(value, str) and value.startswith("iVBORw0KGgo") and len(value) > 1000
+
+
 # --------------------------------------------------------------------------
 # Equivalence classes: {group: (result key, [(label, call), ...])}
 # Every spelling in a group must yield the same value for that key.
@@ -177,6 +182,70 @@ ACCEPTED: dict[str, list] = {
         ("scientific notation", lambda c: S.calculate_expression("1e3", ctx=c),
          "numeric", 1000.0),
     ],
+    "variable: names that shadow Sage objects": [
+        # e, I and N all mean something in Sage's namespace. Used as the
+        # variable of differentiation they must still behave as symbols,
+        # because the tool declares them explicitly.
+        ("e as a variable", lambda c: S.differentiate_expression("e^2", "e", ctx=c),
+         "derivative", "2*e"),
+        ("N as a variable", lambda c: S.differentiate_expression("N^2", "N", ctx=c),
+         "derivative", "2*N"),
+        ("I as a variable", lambda c: S.differentiate_expression("I^2", "I", ctx=c),
+         "derivative", "2*I"),
+        ("gamma as a variable", lambda c: S.differentiate_expression("gamma^2", "gamma", ctx=c),
+         "derivative", "2*gamma"),
+    ],
+    "operation: surrounding whitespace": [
+        # Tool arguments arrive as JSON from a model, so a stray space in an
+        # enum should not be the difference between working and not.
+        ("matrix", lambda c: S.matrix_operation([[1, 2], [3, 4]], " determinant ", ctx=c),
+         "result", -2.0),
+        ("graph", lambda c: S.graph_operation("PetersenGraph", " order ", ctx=c), "result", 10),
+        ("group", lambda c: S.group_operation("SymmetricGroup(4)", " order ", ctx=c),
+         "result", 24),
+        ("number theory", lambda c: S.number_theory_operation(" is_prime ", 7, ctx=c),
+         "result", True),
+    ],
+    "range: numeric spans": [
+        ("negative span", lambda c: S.plot_expression("sin(x)", "x", -6.28, -3.14, ctx=c),
+         "image_base64", _is_png),
+        ("reversed bounds", lambda c: S.plot_expression("sin(x)", "x", 3.0, -3.0, ctx=c),
+         "image_base64", _is_png),
+        ("integer bounds", lambda c: S.plot_expression("sin(x)", "x", -3, 3, ctx=c),
+         "image_base64", _is_png),
+        ("find_root reversed interval",
+         lambda c: S.find_root("x - cos(x)", "x", 1.0, 0.0, ctx=c), "root", 0.7390851332151559),
+    ],
+    "list parameters: arity": [
+        ("one expression", lambda c: S.plot_multi_expression(["sin(x)"], ctx=c),
+         "image_base64", _is_png),
+        ("four expressions",
+         lambda c: S.plot_multi_expression(["sin(x)", "cos(x)", "x", "x^2"], ctx=c),
+         "image_base64", _is_png),
+        ("single ring variable",
+         lambda c: S.polynomial_ring_operation(["a"], ["a^2-1"], "groebner_basis", ctx=c),
+         "result", ["a^2 - 1"]),
+        ("two-dimensional divergence",
+         lambda c: S.vector_calculus_operation("divergence", ["x", "y"], ["x", "y"], ctx=c),
+         "result", "2"),
+    ],
+    "matrix: shapes": [
+        ("1xN times Nx1", lambda c: S.matrix_multiply([[1, 2, 3]], [[1], [2], [3]], ctx=c),
+         "product", [[14.0]]),
+        ("rank of a non-square matrix",
+         lambda c: S.matrix_operation([[1, 2, 3], [4, 5, 6]], "rank", ctx=c), "result", 2),
+        ("1x1 determinant", lambda c: S.matrix_operation([[5]], "determinant", ctx=c),
+         "result", 5.0),
+    ],
+    "distribution: parameter arity": [
+        ("normal with no parameters is standard",
+         lambda c: S.distribution_operation("normal", [], "mean", ctx=c), "result", 0.0),
+        ("normal with no parameters has unit variance",
+         lambda c: S.distribution_operation("normal", [], "variance", ctx=c), "result", 1.0),
+        ("student_t variance needs nu > 2",
+         lambda c: S.distribution_operation("student_t", [5], "variance", ctx=c),
+         "result", 5 / 3),
+    ],
 }
 
 
@@ -184,15 +253,45 @@ ACCEPTED: dict[str, list] = {
 # Invalid input that must fail cleanly rather than return a wrong answer.
 # --------------------------------------------------------------------------
 REJECTED: list = [
+    # --- expression syntax ---
     # Sage does not support implicit multiplication either; the contract is
     # that it fails rather than silently parsing as something else.
     ("implicit multiplication", lambda c: S.differentiate_expression("2x", "x", ctx=c)),
     ("latex input", lambda c: S.calculate_expression(r"\sqrt{4}", ctx=c)),
     ("wrong case function", lambda c: S.calculate_expression("Sin(0)", ctx=c)),
     ("unbalanced parenthesis", lambda c: S.calculate_expression("(2+3", ctx=c)),
+    # --- unknown enum values ---
     ("unknown matrix operation", lambda c: S.matrix_operation([[1]], "nonsense", ctx=c)),
     ("unknown graph operation", lambda c: S.graph_operation("PetersenGraph", "nonsense", ctx=c)),
     ("unknown distribution", lambda c: S.distribution_operation("nonsense", [1], "mean", ctx=c)),
+    # --- degenerate collections ---
+    # An empty matrix is the dangerous one: Sage reads [] as the 0x0 matrix and
+    # reports its determinant as 1.0, which reads like a real answer.
+    ("empty matrix", lambda c: S.matrix_operation([], "determinant", ctx=c)),
+    ("matrix with empty rows", lambda c: S.matrix_operation([[]], "determinant", ctx=c)),
+    ("ragged matrix", lambda c: S.matrix_operation([[1, 2], [3]], "determinant", ctx=c)),
+    # Previously raised a bare "list index out of range" from the median.
+    ("empty statistics data", lambda c: S.statistics_summary([], ctx=c)),
+    ("empty geometry points", lambda c: S.geometry_operation("polygon_area", [], ctx=c)),
+    # Previously returned {'result': None} as though that were an answer.
+    ("distance from a single point",
+     lambda c: S.geometry_operation("distance", [[0, 0]], ctx=c)),
+    # --- shape mismatches ---
+    ("non-conformable multiplication", lambda c: S.matrix_multiply([[1, 2]], [[1, 2]], ctx=c)),
+    ("determinant of a non-square matrix",
+     lambda c: S.matrix_operation([[1, 2, 3], [4, 5, 6]], "determinant", ctx=c)),
+    ("inverse of a singular matrix",
+     lambda c: S.matrix_operation([[1, 2], [2, 4]], "inverse", ctx=c)),
+    # --- degenerate ranges ---
+    ("zero-width plot range", lambda c: S.plot_expression("sin(x)", "x", 1.0, 1.0, ctx=c)),
+    ("root outside the interval", lambda c: S.find_root("x^2 + 1", "x", 0.0, 1.0, ctx=c)),
+    # --- undefined mathematics ---
+    # The mean of a Cauchy distribution genuinely does not exist; saying so is
+    # the correct answer, not a limitation.
+    ("student_t mean at nu = 1",
+     lambda c: S.distribution_operation("student_t", [1], "mean", ctx=c)),
+    ("uniform needs two parameters",
+     lambda c: S.distribution_operation("uniform", [1], "mean", ctx=c)),
 ]
 
 
@@ -252,12 +351,15 @@ async def test_valid_spellings_are_accepted(monkeypatch, group):
                 failures.append(f"{label}: raised {type(exc).__name__}: {exc}")
                 continue
             actual = result.get(key)
-            if isinstance(expected, float):
+            if callable(expected):
+                ok = bool(expected(actual))
+            elif isinstance(expected, float):
                 ok = actual is not None and abs(float(actual) - expected) < 1e-9
             else:
                 ok = actual == expected
             if not ok:
-                failures.append(f"{label}: expected {expected!r}, got {actual!r}")
+                wanted = getattr(expected, "__name__", repr(expected))
+                failures.append(f"{label}: expected {wanted}, got {str(actual)[:80]!r}")
     finally:
         await manager.shutdown()
 


### PR DESCRIPTION
#21 implemented the *shape* of the plan but covered roughly half of the taxonomy. This finishes the remaining axes: **numeric ranges, collection shapes, operation-enum formatting, list-parameter arity, and variable names that collide with Sage's namespace.**

## What probing those axes found

Eleven behaviours worth pinning. **Six were already correct** and are now locked in as contract tests rather than "fixed":

| Input | Behaviour |
|---|---|
| Determinant of a non-square matrix | `self must be a square matrix` |
| Inverse of a singular matrix | `input matrix must be nonsingular` |
| Ragged rows | `inconsistent number of columns` |
| Zero-width plot range | `start point and end point must be different` |
| Root outside the interval | `f appears to have no zero on the interval` |
| Mean of a Cauchy distribution (`student_t`, ν=1) | reported undefined |

That last one is worth stating plainly: undefined mathematics reporting itself as undefined is the **right answer**, not a limitation.

## Five genuine defects

| # | Tool | Defect |
|---|---|---|
| 1 | `statistics_summary([])` | Raised `list index out of range` from the median calculation — says nothing about what to send instead. |
| 2 | `geometry_operation("distance", [one point])` | Generated the literal `"None"` and returned `{'result': None}`, **presenting a missing answer as an answer**. |
| 3 | `matrix_operation([])` | Reported a determinant of **1.0**. Sage reads `[]` as the 0×0 matrix, whose determinant is 1 by convention — so an obvious input mistake produced a plausible-looking number. |
| 4 | `matrix_multiply` non-conformable | Surfaced `unsupported operand parent(s) for *: 'Full MatrixSpace of ...'`, which does not say which dimension is wrong. Now: `Cannot multiply a 1x2 matrix by a 1x2 matrix: the number of columns in matrix_a must equal the number of rows in matrix_b`. |
| 5 | Operation enums | Rejected surrounding whitespace. Arguments arrive as JSON from a model, so `" determinant "` should not be the difference between working and not. Normalised across **all twelve** tools that take one. |

Defects 2 and 3 are the same failure mode as `distribution_operation`'s random-sample "mean" from #18: a wrong or absent value dressed as a real result. That is the class this whole effort exists to catch, and it is why every case asserts a value rather than merely "did not raise".

## Confirmed working, no code change needed

Now covered by tests: `e`, `I`, `N` and `gamma` as variables of differentiation; reversed and negative plot ranges; 1×N by N×1 multiplication; single- and many-element list parameters; distributions with omitted parameters.

## Verification

The suite **fails on both new groups without these fixes**, verified by stashing `server.py`.

| | Result |
|---|---|
| Integration suite (SageMath 10.9) | **319 passed in 64s** (was 313) |
| Unit suite | **246 passed** |
| Runtime budget | 64s against the agreed 180s ceiling |
| `ruff check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA