### PR TITLE
Release v0.4.0: version bump and documentation

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Needed to open the bump pull request, since main is protected and
+      # cannot be pushed to directly.
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -36,30 +39,40 @@ jobs:
         run: |
           NEW_VERSION=$(python scripts/bump_version.py --segment "${{ inputs.segment }}")
           echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-      - name: Commit version bump
+      # main is a protected branch with required status checks, so a direct
+      # push is rejected. The bump goes through a pull request like any other
+      # change, and the release tag is pushed once that merges.
+      - name: Open a version-bump pull request
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml src/sagemath_mcp/__init__.py
-          if git diff --cached --quiet; then
-            echo "No version changes detected; aborting."
-            exit 1
-          fi
-          git commit -m "Bump version to ${NEW_VERSION}"
-      - name: Create git tag
-        env:
-          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if git rev-parse "v${NEW_VERSION}" >/dev/null 2>&1; then
             echo "Tag v${NEW_VERSION} already exists; aborting."
             exit 1
           fi
-          git tag "v${NEW_VERSION}"
-      - name: Push changes
-        env:
-          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
-        run: |
-          git push origin HEAD
-          git push origin "v${NEW_VERSION}"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="release/v${NEW_VERSION}"
+          git checkout -b "${BRANCH}"
+          # Stage every file the bump script touches. Listing files by hand is
+          # what let the Helm chart drift out of sync in earlier releases.
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No version changes detected; aborting."
+            exit 1
+          fi
+          git commit -m "Bump version to ${NEW_VERSION}"
+          git push origin "${BRANCH}"
+          gh pr create \
+            --base "${GITHUB_REF_NAME}" \
+            --head "${BRANCH}" \
+            --title "Bump version to ${NEW_VERSION}" \
+            --body "$(printf '%s\n' \
+              "Automated version bump to \`${NEW_VERSION}\`." \
+              "" \
+              "Merge this, then push the release tag to publish:" \
+              "" \
+              '```' \
+              "git tag v${NEW_VERSION} && git push origin v${NEW_VERSION}" \
+              '```')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,106 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.0] - 2026-08-13
+
+A correctness release. Several tools returned wrong values or did not work at all,
+so **output changes for anything relying on the previous behaviour** — hence a minor
+bump rather than a patch.
+
+### Changed — output differs from 0.3.1
+
+- **`distribution_operation`** now computes `mean` and `variance` analytically.
+  `mean` previously evaluated `get_random_element()`, returning a random draw from
+  the distribution — a different wrong answer on every call — and `variance` was
+  hardcoded to `null`.
+- **`distribution_operation`** now honours both parameters of the normal
+  distribution. `mu` was ignored entirely and `sigma` was dropped unless exactly one
+  parameter was passed, so `[0, 3]` silently computed with `sigma=1` and `[5, 2]` was
+  centred on 0.
+- **`matrix_operation([])`** is now rejected. It previously reported a determinant of
+  `1.0`, because Sage reads `[]` as the 0×0 matrix whose determinant is 1 by
+  convention — an obvious input mistake producing a plausible-looking number.
+- **`geometry_operation("distance", ...)`** with fewer than two points is now
+  rejected. It previously returned `{"result": null}`, presenting a missing answer as
+  an answer.
+- **Base image** moved to `sagemath/sagemath:10.9`. The `sage` account is **uid/gid
+  1001** in 10.9, where it was 1000 in 10.5. Deployments pinning the old numeric UID
+  must be updated; `docker-compose.yml` no longer hardcodes one, and the Helm chart
+  now uses 1001.
+
+### Fixed
+
+- **`solve_ode`** rejected the spelling its own documentation advertised. `diff(y(x),
+  x)` failed with *"Substitution using function-call syntax and unnamed arguments has
+  been removed"*, because the dependent name was bound to the applied expression, so
+  `y(x)` became `(y(x))(x)`. Both `diff(y(x), x)` and `diff(y, x)` now work and give
+  identical results. ([#12](https://github.com/XBP-Europe/sagemath-mcp/issues/12))
+- **All three plot tools** were non-functional. They passed a `BytesIO` to Sage's
+  `save()`, which requires a filesystem path. 2D plots now render through the
+  matplotlib figure; 3D surfaces are sampled and drawn through matplotlib's 3D axes,
+  since `Graphics3d` has no in-memory export.
+- **Results larger than 64 KiB** failed with `LimitOverrunError`. A response is read
+  with a single `readline()`, and asyncio's default stream limit is 64 KiB; a
+  base64-encoded 3D plot is around 100 KiB. Raised to 8 MiB. This affected any large
+  result, not only plots.
+- **`geometry_operation("distance", ...)`** computed `sqrt(-3)` for a 3-4-5 triangle.
+  The generated code used `(a-b)^2`, and `^` is XOR in Python, not exponentiation.
+- **`boolean_algebra_operation`** rejected the documented `x*y + x*z + y*z` with
+  *"name 'x' is not defined"*, because the ring generators are `x0, x1, x2`. Both
+  spellings now parse.
+- **`coding_theory_operation`** documented `ReedSolomonCode(GF(7),3,5)`, which is not
+  a valid constructor in current Sage. The documented example is now
+  `GeneralizedReedSolomonCode(GF(7).list()[:6],3)`.
+- **`graph_operation`** rejected every parameterised constructor. `CompleteGraph(4)`
+  failed with *"name 'CompleteGraph' is not defined"*, which covered most of Sage's
+  catalogue. Bare names, explicit calls, parameterised constructors and adjacency
+  dicts all work.
+- **Symbolic bounds** are accepted by `integrate_expression`, `limit_expression`,
+  `series_expansion` and `symbolic_sum`. Integrating to `a` or summing to `n`
+  previously raised `NameError`. Note that `n` and `N` are `numerical_approx` in
+  Sage's namespace; short names are now treated as free symbols, while `e`, `i` and
+  `I` keep their meaning as constants.
+- **Newlines in expressions** no longer raise a syntax error. These tools evaluate a
+  single expression, so whitespace is folded before evaluation. `evaluate_sage` is
+  unaffected and keeps its newlines.
+- **`matrix_multiply`** reports the offending shapes instead of Sage's *"unsupported
+  operand parent(s) for \*"*.
+- **`statistics_summary([])`** reports what it needs instead of *"list index out of
+  range"*.
+- **Operation names** tolerate surrounding whitespace across all twelve tools that
+  take one.
+
+### Added
+
+- `tests/test_math_examples.py` — every Sage-backed tool is exercised with the
+  examples from its own parameter documentation, against a real Sage runtime.
+- `tests/test_syntax_variants.py` — the input spellings each tool must accept,
+  organised by parameter kind. Equivalent spellings must produce equal results, and
+  invalid input must fail cleanly rather than return a wrong value.
+- `tests/test_generated_code_lint.py` — static checks needing no Sage: `^` in
+  generated Python, `save()` to a buffer, and **any documented example that no test
+  exercises**, which is the guard that makes issue #12 structurally impossible.
+
+### Infrastructure
+
+- **Integration tests now actually run.** The Makefile exec'd `sage-mcp` while CI
+  named the container `sage-mcp-ci`, so every run failed with *"No such container"* —
+  and because the command was piped to `tee`, the exit status was `tee`'s and the job
+  reported success. Every previous green integration result was meaningless.
+- **`pip-audit` is blocking.** It was `continue-on-error`, which is why an authlib
+  advisory (PYSEC-2026-1201) sat in green builds. Transitive dependencies were
+  upgraded to clear 32 findings.
+- GitHub Actions upgraded across the board; dependency floors raised to match the
+  versions actually resolved.
+- Added `.dockerignore`. Without it `COPY . /workspace` ingested the local `.venv`
+  and `.git`, baking a host-built virtualenv into the image.
+- `scripts/bump_version.py` now updates `charts/sagemath-mcp/Chart.yaml`, which had
+  been left behind at every previous release.
+- `version-bump.yml` opens a pull request instead of pushing to `main`, which is now
+  a protected branch.
+
+[0.4.0]: https://github.com/XBP-Europe/sagemath-mcp/releases/tag/v0.4.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,29 @@ Thank you for your interest in improving the SageMath MCP server! This guide exp
 
 ## Releasing
 
-- Follow the instructions in [DISTRIBUTION.md](DISTRIBUTION.md) for PyPI and container releases.
-- Tag releases using `vX.Y.Z` to trigger the GitHub Actions workflows.
+`main` is protected and requires all CI checks, so a release cannot be pushed to it
+directly. The flow is:
+
+1. Run the **Version bump** workflow (`workflow_dispatch`) with the segment to bump. It
+   updates `pyproject.toml`, `src/sagemath_mcp/__init__.py` and
+   `charts/sagemath-mcp/Chart.yaml`, then opens a pull request.
+2. Merge that pull request once CI passes.
+3. Push the tag to publish:
+
+   ```bash
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+
+Pushing the tag triggers `release.yml`, which publishes to PyPI and pushes a
+Cosign-signed image to GHCR. **A PyPI version number can never be reused**, so treat the
+tag push as the point of no return; if something is wrong the only remedy is another
+version.
+
+Record user-visible changes in [CHANGELOG.md](CHANGELOG.md) before tagging. Choose the
+segment by whether *output* changes: a tool returning a different value than the previous
+release is a minor bump even when the new value is the correction of a bug.
+
+See [DISTRIBUTION.md](DISTRIBUTION.md) for the packaging details.
 
 ## Community Expectations
 

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -53,8 +53,14 @@ docker pull ghcr.io/xbp-europe/sagemath-mcp:latest
 ```
 
 Images inherit the upstream `sagemath/sagemath` base and run as the non-root `sage`
-user (UID/GID 1000). Ensure repository directories mounted into the container are
-writable by that user (`chown -R 1000:1000 .` before `docker run`/`docker compose up`).
+user (UID/GID 1001). Ensure repository directories mounted into the container are
+writable by that user (`chown -R 1001:1001 .` before `docker run`/`docker compose up`).
+
+This number comes from the base image and is not ours to choose: `sage` was UID 1000
+through SageMath 10.5 and is 1001 from 10.9. Check it after any base image bump with
+`docker run --rm sagemath/sagemath:<tag> id sage`, and update the Helm chart's
+`runAsUser`/`runAsGroup` to match. `/home/sage` is mode 0750, so a mismatched UID
+cannot even reach the `sage` executable and the container exits immediately.
 
 Helm deployments reference the same image via `charts/sagemath-mcp/values.yaml`. Adjust
 `image.tag` in values or `--set image.tag=<version>` when installing a specific release.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -25,8 +25,8 @@ cd sagemath-mcp
 docker compose up --build
 ```
 
-The container exposes `http://127.0.0.1:8314/mcp` and runs as the non-root `sage` user (UID/GID 1000).
-If you mount the repository from the host, ensure it is writable by that UID (`chown -R 1000:1000 .`
+The container exposes `http://127.0.0.1:8314/mcp` and runs as the non-root `sage` user (UID/GID 1001).
+If you mount the repository from the host, ensure it is writable by that UID (`chown -R 1001:1001 .`
 before launching).
 
 ### Kubernetes (Helm)
@@ -105,6 +105,6 @@ make test
   docker rm -f sage-mcp
   ```
 - When mounting directories into Docker or running via `docker compose`, ensure the host path is
-  writable by UID/GID 1000 to satisfy the non-root `sage` user (e.g., `sudo chown -R 1000:1000 <path>`).
+  writable by UID/GID 1001 to satisfy the non-root `sage` user (e.g., `sudo chown -R 1001:1001 <path>`).
 - Security policy errors (e.g., "Import statements are disabled") typically indicate unsupported
   operations; rewrite the Sage code using whitelisted modules or helper tools.

--- a/MONITORING.md
+++ b/MONITORING.md
@@ -63,7 +63,7 @@ PY
 For Docker Compose deployments the MCP endpoint defaults to `http://127.0.0.1:8314/mcp`. Inside
 Kubernetes, use `kubectl port-forward` (see `charts/sagemath-mcp/templates/NOTES.txt`) or expose an
 ingress before scraping metrics. The chart enforces non-root execution, so ensure any sidecar or job
-containers mounting shared volumes tolerate UID/GID 1000 ownership.
+containers mounting shared volumes tolerate UID/GID 1001 ownership.
 
 Create a small bridge that fetches metrics and exposes a Prometheus-compatible endpoint:
 

--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ Whether the task is symbolic calculus, number theory, linear algebra, differenti
 | **Differential equations** | `solve_ode` | Sage | First- and higher-order ODEs via Sage's `desolve()` |
 | **Number theory** | `number_theory_operation` | Sage | Primality testing, integer factorization, next prime, GCD, LCM |
 | **Combinatorics** | `combinatorics_operation` | Sage | Binomial, permutations, combinations, partitions, factorial, Catalan, Fibonacci, Bell numbers |
-| **Graph theory** | `graph_operation` | Sage | Named graphs and adjacency dicts; chromatic number, connectivity, planarity, diameter, shortest path |
+| **Graph theory** | `graph_operation` | Sage | Named graphs including parameterised constructors (`CompleteGraph(4)`) and adjacency dicts; chromatic number, connectivity, planarity, diameter, shortest path |
 | **Group theory** | `group_operation` | Sage | Symmetric, dihedral, cyclic, alternating groups; order, abelian/cyclic test, center, exponent |
 | **Elliptic curves** | `elliptic_curve_operation` | Sage | Rank, torsion, discriminant, j-invariant, conductor, generators |
-| **Coding theory** | `coding_theory_operation` | Sage | Hamming, Reed-Solomon codes; length, dimension, minimum distance, generator matrix, rate |
+| **Coding theory** | `coding_theory_operation` | Sage | Hamming and generalized Reed-Solomon codes; length, dimension, minimum distance, generator matrix, rate |
 | **Polynomial rings** | `polynomial_ring_operation` | Sage | Groebner bases, ideal dimension/variety, reduction, Groebner test |
-| **Boolean algebra** | `boolean_algebra_operation` | Sage | Boolean polynomial ring; evaluate, variables, degree, zero/one test |
+| **Boolean algebra** | `boolean_algebra_operation` | Sage | Boolean polynomial ring, addressed as `x, y, z` or `x0, x1, x2`; evaluate, variables, degree, zero/one test |
 | **Geometry** | `geometry_operation` | Sage | Distance, polygon area, polytope volume, convex hull, compactness via `Polyhedron` |
 | **Statistics** | `statistics_summary` | Sage | Mean, median, population & sample variance/std dev, min, max |
-| **Probability** | `distribution_operation` | Sage | Normal, exponential, Poisson, chi-squared, Student-t, uniform, beta, gamma; PDF, CDF, quantile, sampling |
+| **Probability** | `distribution_operation` | Sage | Normal, exponential, Poisson, chi-squared, Student-t, uniform, beta, gamma; PDF, CDF, quantile, analytic mean/variance, sampling |
 | **Visualization** | `plot_expression`, `plot3d_expression`, `plot_multi_expression` | Sage | 2D plots, 3D surface plots, multi-function overlays as base64-encoded PNG |
 | **Numeric methods** | `find_root` | Sage | Numeric root-finding in an interval via Sage's `find_root()` |
 | **Vector calculus** | `vector_calculus_operation` | Sage | Gradient, divergence, curl, Laplacian on scalar/vector fields |
@@ -200,7 +200,7 @@ cosign verify ghcr.io/xbp-europe/sagemath-mcp:latest \
 docker compose up --build
 ```
 
-The compose service exposes port `8314` on both host and container and mounts the repository at `/workspace`. Containers run as the non-root `sage` user (UID/GID 1000) to match the base image. Tweak runtime settings by editing the environment block (for example, increase `SAGEMATH_MCP_EVAL_TIMEOUT` or adjust `SAGEMATH_MCP_MAX_STDOUT`) before launch.
+The compose service exposes port `8314` on both host and container and mounts the repository at `/workspace`. Containers run as the non-root `sage` user (UID/GID 1001) to match the base image. Tweak runtime settings by editing the environment block (for example, increase `SAGEMATH_MCP_EVAL_TIMEOUT` or adjust `SAGEMATH_MCP_MAX_STDOUT`) before launch.
 
 ---
 
@@ -295,6 +295,10 @@ Compute indefinite or definite integrals. Calls Sage's `integrate()` function.
 | `lower_bound` | `string` or `null` | `null` | Lower bound for definite integrals. Accepts symbolic values like `"0"`, `"-oo"` (negative infinity), or expressions like `"-pi"`. |
 | `upper_bound` | `string` or `null` | `null` | Upper bound for definite integrals. Accepts `"1"`, `"oo"` (infinity), `"pi/2"`, etc. |
 
+Bounds may also be free symbols, so `upper_bound="a"` integrates to a symbolic limit.
+Names Sage already defines keep their meaning: `e`, `pi` and `oo` are the constants,
+not new variables.
+
 Both `lower_bound` and `upper_bound` must be provided together for a definite integral, or both omitted for an indefinite integral. Providing only one raises an error.
 
 **Returns:** `{"integral": "...", "definite": true/false}`
@@ -308,6 +312,9 @@ Both `lower_bound` and `upper_bound` must be provided together for a definite in
 
 > integrate_expression(expression="e^(-x^2)", lower_bound="-oo", upper_bound="oo")
   {"integral": "sqrt(pi)", "definite": true}
+
+> integrate_expression(expression="x", lower_bound="0", upper_bound="a")
+  {"integral": "1/2*a^2", "definite": true}
 ```
 
 #### `limit_expression`
@@ -524,10 +531,16 @@ Solve an ordinary differential equation using Sage's `desolve()`. The equation i
 | `function` | `string` | `"y"` | Name of the dependent function being solved for. |
 | `variable` | `string` | `"x"` | Name of the independent variable. |
 
+The dependent function may be written either applied (`diff(y(x), x) + y(x)`) or bare
+(`diff(y, x) + y`). Both describe the same equation and return identical solutions.
+
 **Returns:** `{"solution": "..."}`
 
 ```
 > solve_ode(equation="diff(y(x),x) + y(x) = 0")
+  {"solution": "_C*e^(-x)"}
+
+> solve_ode(equation="diff(y,x) + y = 0")     # bare form, same result
   {"solution": "_C*e^(-x)"}
 
 > solve_ode(equation="diff(y(x),x,x) - y(x) = 0")
@@ -778,7 +791,7 @@ Best for remote clients, browser-based tools, or shared environments. Supports s
 docker compose up --build
 ```
 
-Exposes `http://127.0.0.1:8314/mcp`. Runs as non-root `sage` user (UID/GID 1000). The compose file mounts the repository at `/workspace` and accepts environment variable overrides for all `SAGEMATH_MCP_*` settings.
+Exposes `http://127.0.0.1:8314/mcp`. Runs as non-root `sage` user (UID/GID 1001). The compose file mounts the repository at `/workspace` and accepts environment variable overrides for all `SAGEMATH_MCP_*` settings.
 
 ### Kubernetes (Helm)
 
@@ -1160,7 +1173,7 @@ Remaining 1% is defensive `if ctx is not None` branches that are always true in 
 - **AST-based security sandbox** --- every code snippet is validated before execution, blocking `eval`/`exec`, filesystem operations, process spawning, and unauthorized imports. Configurable via environment variables.
 - **Progress heartbeats** --- long-running computations emit periodic progress events (~1.5s) so clients can display activity indicators.
 - **Multiple transports** --- stdio (for Claude Desktop), HTTP, streamable-HTTP, and SSE.
-- **Docker deployment** --- Dockerfile, Docker Compose, and Helm chart for Kubernetes with non-root execution (UID/GID 1000).
+- **Docker deployment** --- Dockerfile, Docker Compose, and Helm chart for Kubernetes with non-root execution (UID/GID 1001).
 - **CI/CD pipeline** --- GitHub Actions with lint, unit tests, integration tests (real Sage in Docker), Docker Compose smoke test, Helm validation, signed GHCR image publishing, and PyPI publishing.
 - **Monitoring resources** --- MCP resources for session snapshots, aggregated metrics, and SageMath documentation links.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,12 @@
 
 This document tracks planned improvements to the SageMath MCP server, organized by priority and effort. The goal is to strengthen the server's position as a universal mathematics MCP server that enables LLMs to perform any symbolic or discrete mathematical operation.
 
-**Current state (v0.3.0-dev):** 33 MCP tools (31 Sage-backed, 2 infrastructure) covering calculus, algebra, linear algebra, ODEs, number theory, combinatorics, graph theory, group theory, elliptic curves, coding theory, boolean algebra, polynomial rings, geometry, probability, vector calculus, statistics, 2D/3D plotting, numeric root-finding, and streaming execution. 242 unit tests at 99% branch coverage, plus 43 CLI integration tests.
+**Current state (v0.4.0):** 33 MCP tools (31 Sage-backed, 2 infrastructure) covering calculus, algebra, linear algebra, ODEs, number theory, combinatorics, graph theory, group theory, elliptic curves, coding theory, boolean algebra, polynomial rings, geometry, probability, vector calculus, statistics, 2D/3D plotting, numeric root-finding, and streaming execution. 246 unit tests, and 319 tests against a real SageMath 10.9 runtime, plus 43 CLI integration tests.
+
+Integration coverage now includes every tool exercised against the examples in its own
+documentation, and a syntax matrix over the input spellings each tool must accept. Both
+run in CI, which had previously reported the integration job as passing while running
+nothing at all.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,55 +1,98 @@
 # Testing Guide
 
 ## Overview
-The test suite verifies Sage session management, MCP tooling, and HTTP-facing helpers.  
-Primary goals:
-- Validate stateful execution, reset/cancel semantics, and timeout handling (`tests/test_session.py`).
-- Confirm MCP bindings emit progress, surface errors, and expose documentation resources (`tests/test_server.py`).
+
+The suite has two halves. Unit tests stub the Sage worker and run anywhere; integration
+tests evaluate real Sage code and only run where Sage is available.
+
+That split matters, because the stubbed half cannot see the code the server *generates*.
+Issue #12 was a tool rejecting the exact input its own documentation advertised, and it
+was invisible to unit tests for precisely that reason. The suites below exist to close
+that gap.
+
+| File | Needs Sage | Covers |
+|------|-----------|--------|
+| `test_session.py` | no | Stateful execution, reset/cancel, timeouts, idle culling |
+| `test_server.py` | no | MCP bindings, progress events, error surfacing, doc resources |
+| `test_security.py` | no | AST policy: blocked imports, calls, attributes |
+| `test_config.py` | no | Environment overrides and invalid values |
+| `test_generated_code_lint.py` | no | Static checks over the code `server.py` generates |
+| `test_integration.py` | **yes** | Real Sage session lifecycle, monitoring, large payloads |
+| `test_math_examples.py` | **yes** | Every tool against the examples in its own documentation |
+| `test_syntax_variants.py` | **yes** | The input spellings each tool must accept or reject |
+| `test_use_cases.py` | **yes** | End-to-end workflows mirroring real LLM usage |
 
 ## Requirements
-- Python 3.12+ and `uv`.  
-- Development extras installed:  
-  ```bash
-  uv pip install -e .[dev]
-  ```
-- For pure unit tests no Sage install is required—the suite forces `SAGEMATH_MCP_PURE_PYTHON=1` and runs the worker in Python mode.
 
-## Running Tests
-```bash
-uv run pytest            # execute entire suite
-uv run pytest tests/test_session.py::test_session_stateful_evaluation  # single test
-```
-Pytest discovers modules inside the `tests/` directory. The configuration is defined in `pyproject.toml` (`asyncio_mode = "auto"`).
+- Python 3.12+ and `uv`
+- Development extras: `uv pip install -e .[dev]`
+- Unit tests need no Sage; they force `SAGEMATH_MCP_PURE_PYTHON=1` and run the worker in
+  Python mode
 
-For integration coverage with a real Sage runtime, either start the helper container (`make sage-container`)
-or bring up the compose stack:
+## Running
 
 ```bash
-docker compose up --build -d
-uv run pytest tests/test_integration.py
+make test                      # unit suite, no Sage required
+make lint                      # ruff
+uv run pytest tests/test_session.py -k test_session_stateful_evaluation   # one test
 ```
 
-CI runs `make all` (unit + integration targets) and captures logs in `integration-artifacts.tar.gz`.
+Integration tests need a Sage container with the repository mounted at `/workspace`:
 
-## Key Fixtures & Patterns
-- `python_settings` fixture in `tests/test_session.py`: injects `force_python_worker=True` to bypass Sage dependencies.
-- `FakeContext` in `tests/test_server.py`: captures info/warning/progress events emitted via the MCP `Context` during tool execution.
-- Async tests use `@pytest.mark.asyncio`; avoid direct `asyncio.run` in tests.
-- `tests/test_config.py` exercises invalid environment overrides to guard the new non-root and timeout
-  settings exposed through `SageSettings`.
-- CI smoke tests also hit `resource://sagemath/monitoring/metrics` via the docker-compose stack to
-  ensure observability endpoints remain healthy.
+```bash
+make sage-container            # start it (reads the image from the Dockerfile)
+make sage-deps                 # install the dev extras into Sage's own Python
+make integration-test          # run the suite inside the container
+```
 
-## Coverage Focus
-- Session lifecycle: `evaluate`, `reset`, `cancel`, idle culling, graceful shutdown.
-- Stateful chat workflows: `tests/test_server.py::test_llm_stateful_average_workflow` and `test_llm_reuses_defined_function` mirror real LLM usage.
-- Error translation & security: `SageEvaluationError` for security violations, metrics recording, and monitoring resource snapshots.
-- Documentation/resource exposure: confirm `resource://sagemath/docs/all` and `resource://sagemath/monitoring/metrics` respond as expected.
+`make sage-deps` is not optional. Sage bundles `pytest` but **not** `pytest-asyncio`, so
+without it every async test errors with *"async def functions are not natively
+supported"*. `make integration-test` depends on it, so running that target alone is
+enough.
 
-## Maintaining Tests
-- Mirror new modules with corresponding files under `tests/` to keep scope targeted.
-- Prefer dependency injection (monkeypatching `SESSION_MANAGER.get/cancel`) over hitting live Sage for unit coverage.
-- When adding features that depend on actual Sage behavior, extend `tests/test_integration.py` and run them inside the Sage container.
-- Ensure new tests run cleanly with `uv run pytest` before submission; lint additional files with `uv run ruff check`.
-- When touching container orchestration or Helm manifests, add smoke coverage by invoking the compose
-  stack or port-forwarding a Helm release and re-running `scripts/exercise_mcp.py` against it.
+To point at a different container, set `SAGEMATH_MCP_DOCKER_CONTAINER`; both the Makefile
+and `scripts/setup_sage_container.sh` honour it, and they must agree. They did not for a
+long period, and because the command was piped to `tee`, the failure was masked by
+`tee`'s exit status and CI reported success while running nothing.
+
+## Writing tests
+
+**Assert a value, not the absence of an exception.** `distribution_operation` returned a
+random sample as the distribution's mean and `null` as its variance. Both would pass a
+check that only confirmed no exception was raised.
+
+**Prove a regression test fails without its fix.** Stash the change, run the test, confirm
+it fails with the expected error, restore. A test that has never failed is not known to
+test anything.
+
+**Document a spelling and it becomes required.** `test_generated_code_lint.py` extracts
+every example from the tools' `Field(description=...)` text and asserts each appears in a
+test. Adding an example to a docstring without a matching test fails the unit suite.
+
+**Prefer equivalence over expected values where possible.** `test_syntax_variants.py`
+asserts that spellings meaning the same thing produce the same answer. That needs no
+hardcoded expectation and catches silently-wrong results, not just errors.
+
+## Key fixtures
+
+- `FakeContext` (`tests/conftest.py`) — captures info/warning/progress events emitted
+  through the MCP `Context`
+- `python_settings` (`tests/test_session.py`) — injects `force_python_worker=True`
+- `requires_sage` — skips when no `sage` executable is on PATH
+- Async tests use `asyncio_mode = "auto"`; do not call `asyncio.run` directly
+
+## CI
+
+Seven jobs, all required by branch protection on `main`: `lint`, `test (3.12)`,
+`test (3.13)`, `security`, `helm`, `integration`, `smoke`.
+
+- `integration` starts the Sage container itself and reads the image from the Dockerfile,
+  so the Sage version has a single source of truth
+- `security` runs `pip-audit` and is **blocking**; a new upstream advisory turns CI red
+  with no repository change
+- `smoke` brings up the compose stack and runs `scripts/exercise_mcp.py` plus the
+  monitoring resource check
+
+Renaming a CI job means updating the required-checks list in branch protection too.
+Otherwise the old name stays required and every pull request waits forever on a check
+that will never report.

--- a/USAGE.md
+++ b/USAGE.md
@@ -11,7 +11,7 @@
   the Docker image automatically.
 - Optional: `sage` on your `PATH` if running outside Docker.
 - `docker compose up --build` launches the bundled stack on `http://127.0.0.1:8314/mcp` using the
-  non-root `sage` user (UID/GID 1000); ensure the mounted project directory is writable by that UID.
+  non-root `sage` user (UID/GID 1001); ensure the mounted project directory is writable by that UID.
 - To deploy to Kubernetes, use the Helm chart in `charts/sagemath-mcp` and set
   `image.repository`/`image.tag` to the published container (non-root execution is enforced by default).
 
@@ -126,4 +126,4 @@ For HTTP transports, point the client at `http://HOST:PORT/mcp` and enable strea
 - **ModuleNotFoundError for `sage`**: ensure the server is launched via `sage -python ...` so Sage’s site-packages are on `PYTHONPATH`.
 - **Long-running jobs**: use `cancel_sage_session`; the server restarts the worker and logs a warning for the calling context.
 - **Idle sessions**: the background culler removes sessions after `SAGEMATH_MCP_IDLE_TTL` seconds (default 900). Adjust via environment variables as documented in `README.md`.
-- **Permission denied on volume mounts**: confirm the host path is writable by UID/GID 1000; adjust ownership with `chown -R 1000:1000 <path>` when using Docker Compose or Helm.
+- **Permission denied on volume mounts**: confirm the host path is writable by UID/GID 1001; adjust ownership with `chown -R 1001:1001 <path>` when using Docker Compose or Helm.

--- a/charts/sagemath-mcp/Chart.yaml
+++ b/charts/sagemath-mcp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sagemath-mcp
 description: A Helm chart for deploying the SageMath MCP server.
 type: application
-version: 0.3.1
-appVersion: "0.3.1"
+version: 0.4.0
+appVersion: "0.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sagemath-mcp"
-version = "0.3.1"
+version = "0.4.0"
 description = "Model Context Protocol server that provides stateful SageMath computations."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -12,12 +12,21 @@ from re import Pattern
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT_PATH = PROJECT_ROOT / "pyproject.toml"
 INIT_PATH = PROJECT_ROOT / "src" / "sagemath_mcp" / "__init__.py"
+CHART_PATH = PROJECT_ROOT / "charts" / "sagemath-mcp" / "Chart.yaml"
 
 PYPROJECT_VERSION_PATTERN: Pattern[str] = re.compile(
     r'^(version\s*=\s*)"(?P<version>\d+\.\d+\.\d+)"\s*$', re.MULTILINE
 )
 INIT_VERSION_PATTERN: Pattern[str] = re.compile(
     r'^(\s*__version__\s*=\s*)"(?P<version>\d+\.\d+\.\d+)"\s*$', re.MULTILINE
+)
+# The chart carries the version twice. Both were left behind by this script,
+# so the chart silently drifted from the package at every release.
+CHART_VERSION_PATTERN: Pattern[str] = re.compile(
+    r"^(version:\s*)(?P<version>\d+\.\d+\.\d+)\s*$", re.MULTILINE
+)
+CHART_APP_VERSION_PATTERN: Pattern[str] = re.compile(
+    r'^(appVersion:\s*)"(?P<version>\d+\.\d+\.\d+)"\s*$', re.MULTILINE
 )
 
 
@@ -59,20 +68,34 @@ def _read_version(path: Path, pattern: Pattern[str]) -> str:
     return match.group("version")
 
 
-def _write_version(path: Path, pattern: Pattern[str], new_version: str) -> None:
+def _write_version(
+    path: Path, pattern: Pattern[str], new_version: str, *, quoted: bool = True
+) -> None:
     content = path.read_text(encoding="utf-8")
     if not pattern.search(content):
         raise RuntimeError(f"Unable to locate version declaration in {path}")
-    updated = pattern.sub(lambda m: f'{m.group(1)}"{new_version}"', content)
+    replacement = f'"{new_version}"' if quoted else new_version
+    updated = pattern.sub(lambda m: f"{m.group(1)}{replacement}", content)
     path.write_text(updated, encoding="utf-8")
+
+
+def _write_all(new_version: str) -> None:
+    """Update every file that carries the version.
+
+    Keep this list complete: the Helm chart was missing, so it stayed on the
+    previous version through every release.
+    """
+    _write_version(PYPROJECT_PATH, PYPROJECT_VERSION_PATTERN, new_version)
+    _write_version(INIT_PATH, INIT_VERSION_PATTERN, new_version)
+    _write_version(CHART_PATH, CHART_VERSION_PATTERN, new_version, quoted=False)
+    _write_version(CHART_PATH, CHART_APP_VERSION_PATTERN, new_version)
 
 
 def bump_version(segment: str) -> Version:
     current_raw = _read_version(PYPROJECT_PATH, PYPROJECT_VERSION_PATTERN)
     current = Version.parse(current_raw)
     bumped = current.bump(segment)
-    _write_version(PYPROJECT_PATH, PYPROJECT_VERSION_PATTERN, str(bumped))
-    _write_version(INIT_PATH, INIT_VERSION_PATTERN, str(bumped))
+    _write_all(str(bumped))
     return bumped
 
 
@@ -99,8 +122,7 @@ def main(argv: list[str] | None = None) -> int:
         print(bumped)
         return 0
 
-    _write_version(PYPROJECT_PATH, PYPROJECT_VERSION_PATTERN, str(bumped))
-    _write_version(INIT_PATH, INIT_VERSION_PATTERN, str(bumped))
+    _write_all(str(bumped))
 
     print(bumped)
     return 0

--- a/src/sagemath_mcp/__init__.py
+++ b/src/sagemath_mcp/__init__.py
@@ -5,5 +5,5 @@ from importlib.metadata import PackageNotFoundError, version
 try:  # pragma: no cover - executed during packaging only
     __version__ = version("sagemath-mcp")
 except PackageNotFoundError:  # pragma: no cover - local dev fallback
-    __version__ = "0.3.1"
+    __version__ = "0.4.0"
 __all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -1674,7 +1674,7 @@ wheels = [
 
 [[package]]
 name = "sagemath-mcp"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Release preparation for **v0.4.0** — version bump, release-tooling fixes, and documentation.

## Why minor, not patch

Several tools now return **different values** than 0.3.1 did, because the old ones were wrong:

- `distribution_operation` reported a **random sample** as the mean and `null` as the variance
- `matrix_operation([])` reported a determinant of **1.0**
- `geometry_operation("distance", [one point])` returned `{"result": null}`
- all three plot tools **did not work at all**

Anything depending on the previous output will see a change, so a patch bump would understate it.

## Documentation

**One correction matters more than the rest.** Five documents told users to `chown -R 1000:1000`, but the `sage` account is **uid 1001** from SageMath 10.9. Following those instructions produces exactly the permission error they exist to prevent. `DISTRIBUTION.md` now records where the number comes from and how to check it after a base-image bump — it is the upstream image's choice, not ours, and it will move again.

**Added `CHANGELOG.md`.** The project had none, and `pyproject.toml` points its Changelog URL at GitHub releases, so there was nowhere to describe behaviour changes. The 0.4.0 entry leads with outputs that differ from 0.3.1, because those are what break callers.

**`TESTING.md` was the most out of date.** It described neither the three new suites nor the container setup they need, and claimed CI runs `make all`, which it does not. It now explains why `make sage-deps` is required (Sage bundles `pytest` but **not** `pytest-asyncio`) and records the container-name convention that must agree between the Makefile and CI — a mismatch there went unnoticed for months behind a `tee` pipe.

**`README`** documents the spellings that now work: applied and bare functions in `solve_ode`, symbolic integration bounds, parameterised graph constructors, both variable spellings in boolean algebra. The capability table no longer advertises Reed-Solomon by a constructor that never existed.

**`CONTRIBUTING`** describes the release flow protection now requires: bump by PR, then tag.

## Release-tooling fixes

**`bump_version.py` now updates the Helm chart.** `Chart.yaml` carries the version twice and neither was touched, so the chart was left behind at **every** release — still declaring 0.3.1 while the package moved on.

**`version-bump.yml` no longer pushes to `main`.** Protection rejects the direct `git push origin HEAD` it performed, so the workflow was broken the moment protection went on. It opens a PR instead, and stages with `git add -A` — hand-listing files is what let the chart drift.

## Verification

| Check | Result |
|---|---|
| Version declarations | `pyproject`, `__init__`, `Chart.yaml` ×2, `uv.lock` all `0.4.0`; nothing reads `0.3.1` |
| Build | `sagemath_mcp-0.4.0-py3-none-any.whl` + sdist |
| `helm lint` | passes on the bumped chart |
| UID claim | Helm chart, Dockerfile and `id sage` in the 10.9 image all agree on **1001** |
| TESTING.md | every `make` target named exists; documented CI job names match the required checks exactly |
| Tests | 246 unit, `ruff` clean |

## After merge

```
git tag v0.4.0 && git push origin v0.4.0
```

That triggers `release.yml` → **PyPI** (a version number can never be reused) and a Cosign-signed GHCR image. It is also the **first live run of `cosign-installer@v4.1.2` and `login-action@v4`**, which PR CI never exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA