### PR TITLE
Create the GitHub release from the workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,3 +115,61 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
+
+  # Runs last so a failed publish cannot leave a release announcing a version
+  # that was never shipped. Until this existed, every release object was created
+  # by hand, and v0.4.0 shipped to PyPI while the releases page still advertised
+  # v0.3.1 as Latest -- which is also where pyproject points its Changelog URL.
+  github-release:
+    needs: [publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+      - name: Extract release notes from the changelog
+        id: notes
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Print the body of the "## [VERSION]" section, stopping at the next one.
+          awk -v ver="$VERSION" '
+            index($0, "## [" ver "]") == 1 { flag = 1; next }
+            flag && index($0, "## [") == 1 { exit }
+            # Link-reference definitions live at the foot of the file; for the
+            # newest entry there is no following section to stop at.
+            flag && /^\[[0-9]+\.[0-9]+\.[0-9]+\]:/ { exit }
+            flag { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ -s release-notes.md ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            # Missing entry is worth surfacing, but not worth failing a release
+            # that has already been published to PyPI.
+            echo "::warning::No CHANGELOG.md entry for ${VERSION}; using generated notes."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "Release ${GITHUB_REF_NAME} already exists; nothing to do."
+            exit 0
+          fi
+          if [ "${{ steps.notes.outputs.found }}" = "true" ]; then
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "${GITHUB_REF_NAME}" \
+              --verify-tag \
+              --notes-file release-notes.md \
+              dist/*
+          else
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "${GITHUB_REF_NAME}" \
+              --verify-tag \
+              --generate-notes \
+              dist/*
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,14 +64,18 @@ directly. The flow is:
    git tag vX.Y.Z && git push origin vX.Y.Z
    ```
 
-Pushing the tag triggers `release.yml`, which publishes to PyPI and pushes a
-Cosign-signed image to GHCR. **A PyPI version number can never be reused**, so treat the
-tag push as the point of no return; if something is wrong the only remedy is another
-version.
+Pushing the tag triggers `release.yml`, which publishes to PyPI, pushes a Cosign-signed
+image to GHCR, and creates the GitHub release. **A PyPI version number can never be
+reused**, so treat the tag push as the point of no return; if something is wrong the only
+remedy is another version.
 
-Record user-visible changes in [CHANGELOG.md](CHANGELOG.md) before tagging. Choose the
+Record user-visible changes in [CHANGELOG.md](CHANGELOG.md) **before** tagging. Choose the
 segment by whether *output* changes: a tool returning a different value than the previous
 release is a minor bump even when the new value is the correction of a bug.
+
+The changelog entry is not optional bookkeeping. The release job reads the
+`## [VERSION]` section and uses it as the release notes; with no entry it falls back to
+generated notes and logs a warning, so the release still ships but says nothing useful.
 
 See [DISTRIBUTION.md](DISTRIBUTION.md) for the packaging details.
 


### PR DESCRIPTION
`release.yml` published to PyPI and GHCR but **never created a release object**. Every previous one was made by hand.

v0.4.0 showed what happens when that's forgotten: the package went live on PyPI while the releases page still advertised **v0.3.1 as Latest** — and `pyproject.toml` points its `Changelog` URL at that page, so metadata shipped *with the package* led somewhere that didn't mention the version being installed.

## The job

Reads the `## [VERSION]` section out of `CHANGELOG.md` and uses it as the release notes, attaching the wheel and sdist as assets.

Three deliberate choices:

- **Runs after `publish`.** A failed upload cannot leave a release announcing a version that was never shipped.
- **A missing changelog entry warns rather than fails.** By that point the package is already on PyPI, and failing the job would not unpublish it — it would only leave the release missing too. It falls back to `--generate-notes`.
- **Exits cleanly if the release already exists**, so re-running a release workflow is safe.

## Verification

| Check | Result |
|---|---|
| Notes extraction against real `CHANGELOG.md` | returns the 0.4.0 section, 97 lines |
| Stops before the link-reference footer | yes — the newest entry has no following section to stop at, so this needed handling |
| Missing-version case | returns 0 lines, triggering the fallback path |
| `bash -n` on both `run` blocks | pass |
| Workflow parses; job graph | `test → build/helm → docker → publish → github-release` |
| Unit tests / lint | 246 passed, clean |

`CONTRIBUTING.md` now states that the changelog entry is load-bearing rather than bookkeeping: with no entry the release still ships, but says nothing useful.

## Caveat

**This cannot be exercised until the next tag push** — the same limitation that applied to the Cosign and login-action upgrades, which did pass on their first live run today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA