### PR TITLE
Record the competitive survey and close the distribution gap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,31 @@ jobs:
         with:
           packages-dir: dist
 
+  # The registry verifies ownership by looking for an "mcp-name:" marker in the
+  # published PyPI description, so this can only run once the package is live.
+  mcp-registry:
+    needs: [publish]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # OIDC, so no long-lived registry token is stored
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Align server.json with the tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' \
+            server.json > server.tmp && mv server.tmp server.json
+          cat server.json
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+      - name: Publish to the MCP registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
+
   # Runs last so a failed publish cannot leave a release announcing a version
   # that was never shipped. Until this existed, every release object was created
   # by hand, and v0.4.0 shipped to PyPI while the releases page still advertised

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SageMath MCP Server
 
+<!-- mcp-name: io.github.XBP-Europe/sagemath-mcp -->
+
 [![CI](https://github.com/XBP-Europe/sagemath-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/XBP-Europe/sagemath-mcp/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/XBP-Europe/sagemath-mcp.svg)](https://github.com/XBP-Europe/sagemath-mcp/releases/latest)
 [![PyPI](https://img.shields.io/pypi/v/sagemath-mcp.svg)](https://pypi.org/project/sagemath-mcp/)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,99 @@ nothing at all.
 
 ---
 
+## Competitive position (surveyed 2026-08-13)
+
+### The SageMath MCP field
+
+| Project | Stars | Language | Tools | Session model | Last push |
+|---------|------:|----------|------:|---------------|-----------|
+| **this project** | **12** | Python | **33** | Subprocess per client, persistent namespace | active |
+| [GaloisHLee/mcp-server-sagemath](https://github.com/GaloisHLee/mcp-server-sagemath) | 11 | TypeScript | 3 | Explicitly stateless | 2025-12 |
+| [sanshanjianke/scicompute-mcp](https://github.com/sanshanjianke/scicompute-mcp) | 4 | Python | multi-backend | Persistent | 2026-04 |
+| [justice8096/sagemath-mcp-server](https://github.com/justice8096/sagemath-mcp-server) | 1 | — | 10 | — | 2026-05 |
+| [szeider/mcp-sage](https://github.com/szeider/mcp-sage) | 1 | Python | 5 | Jupyter kernel, named multi-session | 2026-08 |
+
+The adjacent market is roughly five times larger and is where attention actually goes:
+[mcp-wolframalpha](https://github.com/akalaric/mcp-wolframalpha) (84),
+[sympy-mcp](https://github.com/sdiehl/sympy-mcp) (79),
+[wolframalpha-llm-mcp](https://github.com/Garoth/wolframalpha-llm-mcp) (55),
+[mathematica-mcp](https://github.com/AbhiRawat4841/mathematica-mcp) (44),
+[fermat-mcp](https://github.com/abhiphile/fermat-mcp) (20).
+
+### Where this project leads
+
+- **Sandboxing.** sympy-mcp documents that its parser "uses `eval` under the hood,
+  effectively allowing arbitrary code execution". No SageMath peer documents a sandbox at
+  all. The AST validator with a configurable policy is the clearest differentiator, and
+  only [Eis4TY/Sym-MCP](https://github.com/Eis4TY/Sym-MCP) shares the approach.
+- **Tool surface.** 33 against 3, 5 and 10 for the SageMath peers.
+- **Verification.** 246 unit and 319 real-runtime tests; peer test coverage is largely
+  invisible.
+- **Documentation.** 1218 README lines against 481, 284, 187 and 89.
+- **Operations.** Helm chart, Cosign-signed images, monitoring resource, health endpoint.
+  No peer ships this.
+- **Distribution.** On PyPI with signed releases. Notably sympy-mcp, the most-starred
+  symbolic server, is not on PyPI at all.
+
+### Where this project is behind
+
+1. **Worker transport.** szeider/mcp-sage drives Sage through the Jupyter kernel
+   protocol rather than raw subprocess management, citing "reliable prompt detection,
+   clean separation of stdout / stderr / return values, native interrupt support, and
+   robust multi-line input". Those are precisely the problems this project solved by
+   hand, and a framing bug in that hand-rolled layer surfaced as recently as v0.4.0.
+2. **Interrupt versus restart.** Their `sage_interrupt` sends Ctrl+C and keeps session
+   state. `cancel_sage_session` restarts the worker and discards it, which is the worse
+   outcome when the state was expensive to build.
+3. **One session per client.** They expose `sage_start`, `sage_list` and `sage_stop` for
+   several named sessions at once.
+4. **Install friction.** `uvx mcp-sage` runs with no install via PEP 723 inline
+   dependencies. This project needs a local SageMath or a ~3 GB image.
+5. **Academic anchor.** Their server is cited in a NeSy 2026 paper. This project has no
+   equivalent reference.
+
+---
+
+## Planned — Tier 1: Distribution (done 2026-08-13)
+
+Cheap, and the gap was embarrassing: the repository had no topics, no homepage, and a
+typo in the one sentence GitHub indexes for search.
+
+- [x] Fix the repository description, add a homepage, add 14 discovery topics
+- [x] Add `server.json` and the `mcp-name` ownership marker for the official MCP registry
+- [x] Automate registry publication from the release workflow using OIDC
+- [ ] List on Smithery and Glama, as fermat-mcp does
+
+At the time of the survey the only SageMath server in the official registry was
+`io.github.justice8096/sagemath-mcp-server`, a one-star project with 10 tools. Registry
+publication requires the ownership marker to be present in the *published* PyPI
+description, so it takes effect from the first release after this change.
+
+## Planned — Tier 2: Session ergonomics
+
+The two capabilities where a one-star project is genuinely ahead. Neither needs an
+architectural change.
+
+- [ ] **Interrupt without restart.** Signal the worker and keep the namespace, leaving
+      `cancel_sage_session` as the escape hatch when the worker is unrecoverable.
+- [ ] **Named multi-sessions.** `start` / `list` / `stop` alongside the implicit
+      per-client session, so one client can hold several independent workspaces.
+
+## Under consideration — Tier 3: Jupyter kernel transport
+
+Replacing the JSON-over-stdio worker with `jupyter_client` would retire a class of bugs
+this project keeps paying for: stream framing, interrupt handling and multi-line input.
+It is also a rewrite of `session.py` and `_sage_worker.py`, and the AST validator would
+have to be re-integrated into that path, since the sandbox is the main differentiator and
+cannot be lost in the move. Prototype before committing.
+
+## Explicitly not planned
+
+**More tools.** At 33 the surface already exceeds every peer. The gaps that matter are
+distribution and session ergonomics, not coverage.
+
+---
+
 ## Completed — Phase 1 (High-Value Helper Tools)
 
 - [x] **`symbolic_sum`** — symbolic summation and products with sum/product toggle

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.XBP-Europe/sagemath-mcp",
+  "title": "SageMath",
+  "description": "Stateful SageMath MCP server with 33 symbolic math tools and a sandboxed Sage session per client.",
+  "version": "0.4.0",
+  "websiteUrl": "https://github.com/XBP-Europe/sagemath-mcp",
+  "repository": {
+    "url": "https://github.com/XBP-Europe/sagemath-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "sagemath-mcp",
+      "version": "0.4.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
A survey of the SageMath MCP field, written into `ROADMAP.md`, plus the Tier 1 distribution work.

## What the survey found

This project leads on every axis that takes effort, and trails on the ones that are nearly free.

| | This project | Best peer |
|---|---|---|
| Tools | **33** | 10 |
| Sandbox | AST validator + policy | none documented by any SageMath peer |
| Tests | 246 unit + 319 real-runtime | largely invisible |
| README | 1218 lines | 481 |
| Ops | Helm, signed images, monitoring, health | none |

For contrast, [sympy-mcp](https://github.com/sdiehl/sympy-mcp) (79★, the most-starred symbolic server) states its parser "uses `eval` under the hood, effectively allowing arbitrary code execution" — and is not on PyPI at all.

## Tier 1 — done

The repository had **no topics, no homepage, and a typo in the one sentence GitHub indexes for search** ("sateful"). Fixed directly on the repository, along with 14 discovery topics.

More significant: **the only SageMath server in the official MCP registry was a 1★ project with 10 tools** ([justice8096/sagemath-mcp-server](https://github.com/justice8096/sagemath-mcp-server)). This adds `server.json` and the `mcp-name` ownership marker, published from the release workflow via OIDC so no registry token is stored.

**It takes effect from the next release, not retroactively** — the registry verifies ownership against the marker in the *published* PyPI description, and v0.4.0 shipped without it.

## What the survey says to do next

The actionable findings are not about coverage:

- **[szeider/mcp-sage](https://github.com/szeider/mcp-sage) drives Sage through the Jupyter kernel protocol** rather than a hand-rolled subprocess, citing "native interrupt support" and "clean separation of stdout / stderr / return values". Those are exactly the problems this project solved by hand — and a framing bug in that layer surfaced as recently as v0.4.0 (the 64 KiB `LimitOverrunError`).
- **Their interrupt keeps session state**; `cancel_sage_session` restarts the worker and discards it.
- **They support several named sessions per client**; this project has one.

`ROADMAP.md` therefore proposes **Tier 2** (interrupt-without-restart, named multi-sessions — no architectural change needed) and holds **Tier 3** (kernel transport) open pending a prototype, because the AST sandbox is the main differentiator and must not be lost in such a move.

**Adding more tools is explicitly ruled out.** At 33 the surface already exceeds every peer.

## Verification

- `server.json` satisfies the published schema: required fields present, name matches `^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$`, description 97 chars against the 100 limit
- README marker matches the server name exactly (checked programmatically, not by eye)
- Workflow parses; `mcp-registry` is gated on `publish`, since the registry validates against the live PyPI package
- The `jq` version rewrite produces the expected output for a sample tag
- 246 unit tests, `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA