### PR TITLE
Prototype the Jupyter kernel transport and recommend against it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ __marimo__/
 # Integration artifacts
 integration.log
 integration-artifacts.tar.gz
+
+# Prototype spikes are runnable but not part of the package build.
+prototypes/**/__pycache__/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -96,13 +96,38 @@ computation everyone is trying to stop finishes on its own. And the worker's
 handling it explicitly the worker exited and took the namespace with it, defeating the
 purpose.
 
-## Under consideration — Tier 3: Jupyter kernel transport
+## Tier 3: Jupyter kernel transport — prototyped, not adopted (2026-08-13)
 
-Replacing the JSON-over-stdio worker with `jupyter_client` would retire a class of bugs
-this project keeps paying for: stream framing, interrupt handling and multi-line input.
-It is also a rewrite of `session.py` and `_sage_worker.py`, and the AST validator would
-have to be re-integrated into that path, since the sandbox is the main differentiator and
-cannot be lost in the move. Prototype before committing.
+Prototyped under `prototypes/jupyter_transport/`; see its `FINDINGS.md`. **Recommendation
+is not to adopt now**, on evidence rather than taste.
+
+The motivating benefits were already banked by cheaper means. Interrupt with state
+preservation shipped in Tier 2 using plain SIGINT. The framing failure was fixed by
+sizing the stream limit to 8 MiB. Multi-line input already worked. Of the four advantages
+szeider/mcp-sage cites, only "ZMQ framing has no arbitrary ceiling" is still outstanding,
+against our large one.
+
+What the prototype established:
+
+- A Jupyter kernel listens on five local TCP ports. A second client holding only the
+  connection file executed `import os; os.getuid()` against a stock kernel — so
+  client-side validation would be **advisory only**.
+- **IPython's `ast_transformers` cannot serve as the gate.** A transformer that raises is
+  not a veto: IPython warns, runs the original code anyway, and unregisters the
+  transformer.
+- Keeping the sandbox therefore requires subclassing the kernel and validating in
+  `do_execute`. That works and closes the bypass, but means owning a kernel subclass and
+  tracking ipykernel internals indefinitely.
+- Startup goes from 463 ms to 1010 ms, on a path users wait for.
+- The threat model worsens: today a worker has no listening socket, so a same-user
+  process cannot reach another session. With kernels it can, even if only with validated
+  code.
+
+Revisit for **capability**, not robustness: kernels emit `display_data` with `image/png`
+and `text/latex` natively, which is exactly what the plot tools hand-roll today, and
+`plot3d_expression` had to sample a surface by hand because `Graphics3d` has no
+in-memory export. Notebook interoperability and multi-language kernels are the other
+reasons that would justify the move.
 
 ## Explicitly not planned
 

--- a/prototypes/jupyter_transport/FINDINGS.md
+++ b/prototypes/jupyter_transport/FINDINGS.md
@@ -1,0 +1,100 @@
+# Tier 3 prototype: Jupyter kernel transport
+
+**Recommendation: do not adopt now.** The problems that motivated it have since been
+solved more cheaply, and the move would cost a permanent custom kernel plus a local
+network surface the current design does not have.
+
+Reproduce with `sage -python spike.py` inside the Sage container.
+
+## Why this was on the roadmap
+
+[szeider/mcp-sage](https://github.com/szeider/mcp-sage) drives Sage through the Jupyter
+kernel protocol and cites "reliable prompt detection, clean separation of stdout / stderr
+/ return values, native interrupt support, and robust multi-line input". Those were real
+gaps against a hand-rolled JSON-over-stdio worker, and a framing bug in ours surfaced as
+recently as v0.4.0.
+
+## What the prototype measured
+
+| Question | Result |
+|----------|--------|
+| Does the AST policy survive? | **Only with a custom kernel.** Stock ipykernel executes blocked code. |
+| Startup cost | **1010 ms** vs **463 ms** for the current worker (+547 ms, 2.2×) |
+| Interrupt preserves state? | Yes — and so does the SIGINT implementation already shipped |
+| Large payloads | 2 MB round-trips fine — as it now does over stdio with an 8 MiB limit |
+
+### The policy finding, in detail
+
+A Jupyter kernel listens on five TCP ports on 127.0.0.1, authenticated by an HMAC key in
+a connection file (mode 0600). Any process able to read that file can execute code in the
+kernel. Measured against a stock kernel, with a second client attaching using only the
+connection file:
+
+```
+stock ipykernel   same client : EXECUTED 1001      # import os; os.getuid()
+                  2nd client  : EXECUTED 1001
+guarded kernel    same client : REFUSED (SecurityViolation: Import statements...)
+                  2nd client  : REFUSED (SecurityViolation: Import statements...)
+```
+
+So client-side validation would be **advisory only**: the socket is a second door.
+
+**IPython's `ast_transformers` cannot be used as the gate.** A transformer that raises is
+not a veto. IPython emits a `UserWarning`, executes the original code anyway, and
+silently unregisters the transformer:
+
+```
+install  -> 'installed'
+1st run  -> UserWarning: AST transformer <...> threw an error ... ; result 42
+2nd run  -> result 42
+transformers left -> 0
+```
+
+That leaves exactly one way to keep the sandbox: subclass the kernel and validate in
+`do_execute`, as `guarded_kernel.py` does. It works, and it closes the socket bypass —
+but it means owning a kernel subclass and tracking ipykernel's internals indefinitely.
+
+## Why not now
+
+**The motivating benefits are already banked.** Interrupt with state preservation shipped
+in Tier 2 using plain SIGINT, and is verified against a real Sage runtime. The framing
+failure was fixed by sizing the stream limit to 8 MiB. Multi-line input already works.
+Of the four cited advantages, the only one left is that ZMQ framing has no arbitrary
+ceiling where ours has a large one.
+
+**The costs are concrete.** Startup more than doubles, on a path users wait for. Two
+heavy dependencies join the runtime. Most importantly the sandbox — the project's main
+differentiator against every peer — would depend on a kernel subclass rather than on the
+worker having no other input than its own stdin.
+
+**The threat model gets worse, not better.** Today a worker has no listening socket at
+all; to inject code you must already control the server process. With kernels, every
+session opens local ports, and a same-user process can execute *validated* code in
+another session's namespace. Pipes make that structurally impossible. One question is
+also unresolved: `debugpy` is present in Sage's Python, and although the guarded kernel
+does not advertise `debugger`, whether a crafted `debug_request` can evaluate outside
+`do_execute` was not established.
+
+## What would change the answer
+
+- **Rich display.** Kernels emit `display_data` with `image/png` and `text/latex`
+  natively. The plot tools currently hand-roll base64 PNGs and `plot3d_expression` had to
+  sample a surface manually because `Graphics3d` has no in-memory export. A kernel makes
+  that the transport's job.
+- **Notebook interoperability**, or exposing the same session to a Jupyter front end.
+- **Other language kernels** through one interface, which is roughly what
+  [scicompute-mcp](https://github.com/sanshanjianke/scicompute-mcp) does with multiple
+  backends.
+
+Those are reasons about capability. Adopting for robustness alone is no longer justified.
+
+## Files
+
+- `guarded_kernel.py` — kernel subclass validating in `do_execute`; the only approach
+  found that keeps the policy intact
+- `spike.py` — the measurement harness
+
+Note on the harness: an early version read only iopub and reported a refusal as
+`EXECUTED None`, because a kernel refusing in `do_execute` reports it in the **shell
+reply** and emits nothing on iopub. It now reads both. Worth knowing before trusting any
+similar measurement.

--- a/prototypes/jupyter_transport/guarded_kernel.py
+++ b/prototypes/jupyter_transport/guarded_kernel.py
@@ -1,0 +1,78 @@
+"""A SageMath IPython kernel that enforces the project's AST policy.
+
+Stock ipykernel executes whatever arrives on its shell socket. That is fine for
+a notebook the user drives, and unacceptable here: the AST validator is this
+project's main differentiator, and a Jupyter transport would otherwise reduce it
+to an advisory client-side check.
+
+Validating in ``do_execute`` means every execute_request is checked no matter
+which client sent it, closing the socket bypass that a client-side check leaves
+open.
+
+Launched as:
+    sage -python -m guarded_kernel -f {connection_file}
+"""
+
+from __future__ import annotations
+
+import ast
+
+from ipykernel.ipkernel import IPythonKernel
+from ipykernel.kernelapp import IPKernelApp
+
+from sagemath_mcp.security import SECURITY_POLICY, validate_module
+
+
+class GuardedSageKernel(IPythonKernel):
+    """IPython kernel that refuses code the security policy rejects."""
+
+    implementation = "sagemath-mcp-guarded"
+    implementation_version = "0.1.0"
+
+    def _validate(self, code: str) -> dict | None:
+        """Return an error reply if *code* violates policy, else None."""
+        try:
+            module = ast.parse(code, mode="exec", type_comments=True)
+            validate_module(module, code=code, policy=SECURITY_POLICY)
+        except SyntaxError as exc:
+            return {
+                "status": "error",
+                "ename": "SyntaxError",
+                "evalue": str(exc),
+                "traceback": [f"SyntaxError: {exc}"],
+                "execution_count": self.execution_count,
+            }
+        except Exception as exc:
+            return {
+                "status": "error",
+                "ename": type(exc).__name__,
+                "evalue": str(exc),
+                "traceback": [f"{type(exc).__name__}: {exc}"],
+                "execution_count": self.execution_count,
+            }
+        return None
+
+    async def do_execute(  # type: ignore[override]
+        self,
+        code,
+        silent,
+        store_history=True,
+        user_expressions=None,
+        allow_stdin=False,
+        **kwargs,
+    ):
+        rejection = self._validate(code)
+        if rejection is not None:
+            return rejection
+        return await super().do_execute(
+            code,
+            silent,
+            store_history=store_history,
+            user_expressions=user_expressions,
+            allow_stdin=allow_stdin,
+            **kwargs,
+        )
+
+
+if __name__ == "__main__":
+    IPKernelApp.launch_instance(kernel_class=GuardedSageKernel)

--- a/prototypes/jupyter_transport/spike.py
+++ b/prototypes/jupyter_transport/spike.py
@@ -1,0 +1,179 @@
+"""Evaluate a Jupyter-kernel transport against the current subprocess worker.
+
+Answers four questions with measurements rather than argument:
+  1. Does the AST policy survive the move, including from a second client?
+  2. What does a kernel cost to start, compared with the current worker?
+  3. Does interrupt preserve state, as it now does with SIGINT?
+  4. Do large payloads survive, the failure that produced the 8 MiB stream limit?
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+from queue import Empty
+
+from jupyter_client import BlockingKernelClient, KernelManager
+from jupyter_client.kernelspec import KernelSpec
+
+HERE = Path(__file__).resolve().parent
+
+
+def start_kernel(guarded: bool) -> KernelManager:
+    if guarded:
+        argv = ["sage", "-python", "-m", "guarded_kernel", "-f", "{connection_file}"]
+    else:
+        argv = ["sage", "-python", "-m", "ipykernel_launcher", "-f", "{connection_file}"]
+    km = KernelManager()
+    km._kernel_spec = KernelSpec(
+        resource_dir="", argv=argv, display_name="Sage", language="python"
+    )
+    # The guarded kernel is a module in this directory.
+    env = dict(os.environ)
+    env["PYTHONPATH"] = f"{HERE}:{env.get('PYTHONPATH', '')}"
+    km.start_kernel(cwd=str(HERE), env=env)
+    return km
+
+
+def run(client, code: str, timeout: int = 60) -> dict:
+    """Execute and collect both iopub output and the shell reply.
+
+    The shell reply matters: a kernel that refuses in do_execute reports it as
+    the reply status, and nothing is emitted on iopub. Reading only iopub makes
+    a refusal look identical to a statement that produced no value.
+    """
+    mid = client.execute(code, silent=False, store_history=False)
+    out = {"result": None, "error": None, "stdout": "", "reply": None}
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            msg = client.get_iopub_msg(timeout=5)
+        except Empty:
+            break
+        if msg["parent_header"].get("msg_id") != mid:
+            continue
+        t, c = msg["msg_type"], msg["content"]
+        if t == "stream" and c["name"] == "stdout":
+            out["stdout"] += c["text"]
+        elif t == "execute_result":
+            out["result"] = c["data"].get("text/plain")
+        elif t == "error":
+            out["error"] = f"{c['ename']}: {c['evalue'][:70]}"
+        elif t == "status" and c["execution_state"] == "idle":
+            break
+    try:
+        reply = client.get_shell_msg(timeout=10)
+        content = reply["content"]
+        out["reply"] = content.get("status")
+        if content.get("status") == "error" and not out["error"]:
+            out["error"] = f"{content.get('ename')}: {str(content.get('evalue'))[:70]}"
+    except Empty:
+        pass
+    return out
+
+
+BLOCKED = "import os\nos.getuid()"
+
+
+def q1_policy_survives() -> None:
+    print("\n1. Does the AST policy survive the move?")
+    for label, guarded in (("stock ipykernel", False), ("guarded kernel", True)):
+        km = start_kernel(guarded)
+        kc = km.client()
+        kc.start_channels()
+        kc.wait_for_ready(timeout=90)
+        legit = run(kc, "2 + 2")
+        blocked = run(kc, BLOCKED)
+        atk = BlockingKernelClient()
+        atk.load_connection_file(km.connection_file)
+        atk.start_channels()
+        atk.wait_for_ready(timeout=90)
+        second = run(atk, BLOCKED)
+        def verdict(r):
+            return f"REFUSED ({r['error'][:34]})" if r["error"] else f"EXECUTED {r['result']}"
+
+        print(f"   {label:16} legit={legit['result']}")
+        print(f"   {'':16}   same client : {verdict(blocked)}")
+        print(f"   {'':16}   2nd client  : {verdict(second)}")
+        atk.stop_channels()
+        kc.stop_channels()
+        km.shutdown_kernel(now=True)
+
+
+def q2_startup_cost() -> None:
+    print("\n2. What does startup cost?")
+    start = time.perf_counter()
+    km = start_kernel(True)
+    kc = km.client()
+    kc.start_channels()
+    kc.wait_for_ready(timeout=90)
+    run(kc, "from sage.all import *")
+    kernel_ms = (time.perf_counter() - start) * 1000
+    kc.stop_channels()
+    km.shutdown_kernel(now=True)
+
+    sys.path.insert(0, "/workspace/src")
+    from sagemath_mcp.config import SageSettings
+    from sagemath_mcp.session import SageSession
+
+    async def worker_start() -> float:
+        session = SageSession("bench", SageSettings(force_python_worker=False))
+        begin = time.perf_counter()
+        await session.evaluate("1", want_latex=False, capture_stdout=False)
+        elapsed = (time.perf_counter() - begin) * 1000
+        await session.shutdown()
+        return elapsed
+
+    worker_ms = asyncio.run(worker_start())
+    print(f"   jupyter kernel ready : {kernel_ms:8.0f} ms")
+    print(f"   current worker ready : {worker_ms:8.0f} ms")
+    print(f"   delta                : {kernel_ms - worker_ms:+8.0f} ms")
+
+
+def q3_interrupt_keeps_state() -> None:
+    print("\n3. Does interrupt preserve state?")
+    km = start_kernel(True)
+    kc = km.client()
+    kc.start_channels()
+    kc.wait_for_ready(timeout=90)
+    run(kc, "treasure = 12345")
+    kc.execute("x = 0\nfor i in range(10**9):\n    x += i\nx", silent=False)
+    time.sleep(1.5)
+    km.interrupt_kernel()
+    time.sleep(1.0)
+    # Drain whatever the interrupted execution emitted.
+    while True:
+        try:
+            kc.get_iopub_msg(timeout=2)
+        except Empty:
+            break
+    kept = run(kc, "treasure")
+    print(f"   after interrupt, treasure = {kept['result']}  "
+          f"({'preserved' if kept['result'] == '12345' else 'LOST'})")
+    kc.stop_channels()
+    km.shutdown_kernel(now=True)
+
+
+def q4_large_payload() -> None:
+    print("\n4. Do large payloads survive?")
+    km = start_kernel(True)
+    kc = km.client()
+    kc.start_channels()
+    kc.wait_for_ready(timeout=90)
+    for size in (100_000, 2_000_000):
+        got = run(kc, f"'x' * {size}")
+        length = len(got["result"] or "")
+        print(f"   {size:>9,} chars -> returned {length:>9,}  "
+              f"({'ok' if length >= size else 'TRUNCATED/FAILED'})")
+    kc.stop_channels()
+    km.shutdown_kernel(now=True)
+
+
+if __name__ == "__main__":
+    q1_policy_survives()
+    q2_startup_cost()
+    q3_interrupt_keeps_state()
+    q4_large_payload()


### PR DESCRIPTION
Tier 3 asked whether to replace the JSON-over-stdio worker with `jupyter_client`. This prototypes it and answers with measurements.

**Recommendation: do not adopt now.**

## The security question decided it

A Jupyter kernel listens on **five local TCP ports**, authenticated by a key in a 0600 connection file. A second client holding only that file executed `import os; os.getuid()` against a stock kernel and got `1001` back — so validating on the client side would be **advisory only**. The socket is a second door.

**IPython's `ast_transformers` cannot serve as the gate.** This is the finding I'd have got wrong by reasoning alone. A transformer that raises is *not* a veto:

```
install  -> 'installed'
1st run  -> UserWarning: AST transformer threw an error ... ; result 42
2nd run  -> result 42
transformers left -> 0
```

IPython warns, runs the original code anyway, and silently unregisters the transformer.

That leaves exactly one way to keep the sandbox: subclass the kernel and validate in `do_execute`, which `guarded_kernel.py` does. **It works** — both the first and a second client are refused:

```
stock ipykernel   same client : EXECUTED 1001
                  2nd client  : EXECUTED 1001
guarded kernel    same client : REFUSED (SecurityViolation: Import statements...)
                  2nd client  : REFUSED (SecurityViolation: Import statements...)
```

But it means owning a kernel subclass and tracking ipykernel internals indefinitely — to hold a property the current design gets for free from having no socket at all.

## Meanwhile the benefits have gone

Of the four advantages szeider/mcp-sage cites, three are already banked:

| Motivation | Status |
|---|---|
| Native interrupt | Shipped in Tier 2 over plain SIGINT, verified against real Sage |
| Stream framing | Fixed by sizing the stream limit to 8 MiB |
| Multi-line input | Already worked |
| Clean stdout/stderr separation | Marginal — already separated |

| Measurement | Kernel | Current worker |
|---|---:|---:|
| Startup to ready | **1010 ms** | **463 ms** |
| 2 MB payload | ok | ok |
| Interrupt keeps state | yes | yes |

Startup more than doubles, on a path users wait for.

## The threat model gets worse

Today a worker has no listening socket; to inject code you must already control the server process. With kernels, every session opens local ports and a same-user process can execute code in *another session's* namespace — validated code, with the guarded kernel, but still cross-session reach that pipes make structurally impossible.

**Left open honestly**: `debugpy` is present in Sage's Python. The guarded kernel does not advertise `debugger`, but whether a crafted `debug_request` can evaluate outside `do_execute` was not established.

## What would change the answer

Capability, not robustness. Kernels emit `display_data` with `image/png` and `text/latex` natively — exactly what the plot tools hand-roll today, and why `plot3d_expression` samples a surface by hand after `Graphics3d` turned out to have no in-memory export. Notebook interoperability and multi-language kernels are the other real reasons.

## Contents

- `prototypes/jupyter_transport/guarded_kernel.py` — the only approach found that keeps the policy intact
- `prototypes/jupyter_transport/spike.py` — the measurement harness
- `prototypes/jupyter_transport/FINDINGS.md` — full writeup
- `ROADMAP.md` — Tier 3 marked prototyped-not-adopted, with what would revisit it

Nothing in `src/` changes; this is evidence for a decision, not a migration.

One note on method: an early harness read only iopub and reported a refusal as `EXECUTED None`, because a kernel refusing in `do_execute` reports it in the **shell reply** and emits nothing on iopub. Reading only iopub would have made the guarded kernel look broken and reversed the conclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA