### PR TITLE
Reject integers that JSON already corrupted

### DIFF
--- a/src/sagemath_mcp/server.py
+++ b/src/sagemath_mcp/server.py
@@ -515,6 +515,40 @@ def _declare_free_symbols(*sources: str | None) -> str:
     return "; ".join(parts)
 
 
+# Beyond 2^53 a JSON number is no longer exactly representable as an IEEE
+# double, which is what JavaScript-based MCP clients parse numbers into.
+_EXACT_JSON_INT_LIMIT = 2**53
+
+
+def _exact_int(value: int | str | float, name: str) -> int:
+    """Coerce a tool argument to an exact integer, refusing lossy input.
+
+    A float here means the value already went through a double. 10^30 arrives
+    as 1000000000000000019884624838656, and next_prime() on that returns a
+    perfectly plausible wrong answer -- the failure mode is a wrong number, not
+    an error, which is why this rejects rather than rounds.
+    """
+    if isinstance(value, bool):  # bool is an int subclass; never meant here
+        raise ToolError(f"'{name}' must be an integer, got a boolean")
+    if isinstance(value, str):
+        text = value.strip().replace("_", "")
+        try:
+            return int(text, 10)
+        except ValueError:
+            raise ToolError(f"'{name}' is not a decimal integer: {value!r}") from None
+    if isinstance(value, float):
+        if not value.is_integer():
+            raise ToolError(f"'{name}' must be a whole number, got {value!r}")
+        if abs(value) > _EXACT_JSON_INT_LIMIT:
+            raise ToolError(
+                f"'{name}' arrived as a floating-point number larger than 2^53, so its "
+                "exact value is already lost. Pass it as a decimal string instead, "
+                f'for example "{int(value)}".'
+            )
+        return int(value)
+    return int(value)
+
+
 def _check_matrix(rows: list[list[float]], name: str) -> None:
     """Reject shapes Sage would only complain about obscurely, or not at all.
 
@@ -1101,13 +1135,28 @@ async def number_theory_operation(
         str,
         Field(description="Operation: 'is_prime', 'factor_integer', 'next_prime', 'gcd', 'lcm'"),
     ],
-    a: Annotated[int, Field(description="Primary integer argument")],
-    b: Annotated[int | None, Field(description="Second integer (required for gcd, lcm)")] = None,
+    a: Annotated[
+        int | str,
+        Field(
+            description=(
+                "Primary integer. Pass values above 2^53 as a decimal STRING: "
+                "JSON numbers are IEEE doubles in JavaScript-based clients, so "
+                "10^30 arrives as 1000000000000000019884624838656 and the answer "
+                "is silently wrong."
+            )
+        ),
+    ],
+    b: Annotated[
+        int | str | None,
+        Field(description="Second integer, required for gcd and lcm. Same string rule."),
+    ] = None,
     ctx: Context | None = None,
 ) -> dict:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required for stateful execution")
     operation = operation.strip()
+    a = _exact_int(a, "a")
+    b = _exact_int(b, "b") if b is not None else None
     allowed_ops = {"is_prime", "factor_integer", "next_prime", "gcd", "lcm"}
     if operation not in allowed_ops:
         raise ToolError(
@@ -1173,8 +1222,15 @@ async def combinatorics_operation(
     operation: Annotated[
         str,
         Field(
-            description="One of: binomial, permutations, combinations, "
-            "partitions, factorial, catalan, fibonacci, bell"
+            # Every entry says what it returns. "partitions" alone left it
+            # ambiguous whether the result was a count or a list of partitions,
+            # and a client asking "how many partitions does 120 have" reached
+            # for evaluate_sage rather than risk the wrong shape.
+            description="One of: binomial (n choose k), permutations (n!), "
+            "combinations (n choose k), partitions (COUNT of integer partitions "
+            "of n), factorial (n!), catalan (nth Catalan number), fibonacci "
+            "(nth Fibonacci number), bell (nth Bell number). All return a single "
+            "integer."
         ),
     ],
     n: Annotated[int, Field(description="Primary integer argument")],

--- a/tests/test_generated_code_lint.py
+++ b/tests/test_generated_code_lint.py
@@ -69,12 +69,17 @@ def _non_code_strings(tree: ast.Module) -> set[str]:
         if isinstance(node, ast.Call):
             func = node.func
             is_compile = isinstance(func, ast.Attribute) and func.attr == "compile"
+            # Error messages are prose shown to the caller, never executed, and
+            # they legitimately mention notation such as 2^53.
+            is_error = isinstance(func, ast.Name) and func.id in {
+                "ToolError", "ValueError", "RuntimeError", "SageProcessError",
+            }
             for keyword in node.keywords:
                 if keyword.arg == "description":
                     for sub in ast.walk(keyword.value):
                         if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
                             excluded.add(sub.value)
-            if is_compile:
+            if is_compile or is_error:
                 for arg in node.args:
                     for sub in ast.walk(arg):
                         if isinstance(sub, ast.Constant) and isinstance(sub.value, str):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2062,3 +2062,62 @@ async def test_named_sessions_listed_per_client(monkeypatch):
         assert [entry["name"] for entry in listed["sessions"]] == ["beta"]
     finally:
         await manager.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (12, 12),
+        ("12", 12),
+        (12.0, 12),
+        ("1000000000000000000000000000000", 10**30),
+        (10**30, 10**30),
+        ("1_000", 1000),
+    ],
+)
+async def test_exact_int_accepts_lossless_forms(value, expected):
+    assert server._exact_int(value, "a") == expected
+
+
+@pytest.mark.asyncio
+async def test_exact_int_rejects_a_value_that_already_lost_precision():
+    """A float above 2^53 has already been mangled; refuse rather than round.
+
+    JSON numbers are IEEE doubles in JavaScript-based MCP clients, so 10^30
+    arrives as 1000000000000000019884624838656. next_prime() on that returns a
+    perfectly plausible wrong answer, which is worse than an error.
+    """
+    with pytest.raises(ToolError, match="larger than 2\\^53"):
+        server._exact_int(1e30, "a")
+
+    # The message has to tell the caller what to do instead.
+    try:
+        server._exact_int(1e30, "a")
+    except ToolError as exc:
+        assert "decimal string" in str(exc)
+
+
+@pytest.mark.asyncio
+async def test_exact_int_rejects_non_integers():
+    with pytest.raises(ToolError, match="whole number"):
+        server._exact_int(12.5, "a")
+    with pytest.raises(ToolError, match="not a decimal integer"):
+        server._exact_int("twelve", "a")
+    with pytest.raises(ToolError, match="boolean"):
+        server._exact_int(True, "a")
+
+
+@pytest.mark.asyncio
+async def test_number_theory_accepts_big_integers_as_strings(monkeypatch):
+    """The documented escape hatch for values JSON cannot carry exactly."""
+    session = StubSession("1000000000000000000000000000057")
+    await _stub_manager(monkeypatch, session)
+    result = await server.number_theory_operation(
+        "next_prime", "1000000000000000000000000000000", ctx=FakeContext()
+    )
+    # _evaluate_structured parses the worker's repr, so this comes back as an int.
+    assert result["result"] == 10**30 + 57
+    # The generated code must carry the exact value, not a float repr.
+    assert "1000000000000000000000000000000" in session.calls[0]["code"]
+    assert "e+30" not in session.calls[0]["code"]


### PR DESCRIPTION
Found while investigating why two questions still routed to `evaluate_sage` after #29. The routing hypothesis was wrong — but it led to a real defect.

## The bug

`number_theory_operation` typed its arguments as `int`, and a float above 2⁵³ was silently coerced:

```
int   10**30 -> 1000000000000000000000000000057   correct
float 1e30   -> 1000000000000000019884624838797   wrong, no error
```

**JSON numbers are IEEE doubles in JavaScript-based clients, and Gemini CLI is one.** 10³⁰ arrives as `1000000000000000019884624838656`, and the tool returned a plausible-looking wrong prime instead of failing.

That is the worst available outcome and the same class as two defects found earlier this session: `distribution_operation` returning a random sample as the mean, and `matrix_operation([])` reporting a determinant of `1.0`. A caller cannot tell any of them from a correct answer.

## The fix

`_exact_int` refuses a float above 2⁵³ and names the remedy in the error:

> `'a'` arrived as a floating-point number larger than 2^53, so its exact value is already lost. Pass it as a decimal string instead, for example `"1000000000000000000000000000000"`.

The argument type is now `int | str`, so a decimal string is the exact path, and the description says when to use it. Non-integral floats, non-numeric strings and booleans are rejected.

```
float 1e30 (JS-corrupted)  -> ToolError, with instructions
string "10^30"             -> 1000000000000000000000000000057
exact int 10**30           -> 1000000000000000000000000000057
small float 12.0           -> 13
non-integral 12.5          -> ToolError
```

## Also

Every `combinatorics_operation` operation now states what it returns. `partitions` alone did not say whether the result was a count or a list — and the failing question was "how **many** partitions does 120 have".

## On the routing hypothesis: disconfirmed

Both holdouts still choose `evaluate_sage` after these changes. Descriptions are not the lever for them; they look like questions mapping onto a Sage one-liner the model is confident writing. Recorded rather than quietly dropped.

Note `ext-comb-partitions` passes **n=120**, far too small for any integer-size concern, so the int hypothesis never applied there at all.

## Tests

- `_exact_int` across lossless forms, the 2⁵³ boundary, non-integers, booleans
- The string path reaches the generated code exactly, with no `e+30`
- The caret lint flagged the new error message ("2^53"). Error prose is not generated code, so `ToolError` joins `re.compile` in the exclusions — and **reintroducing the geometry XOR bug still fails the lint**, confirming widening it did not blunt it

267 unit tests, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA