### PR TITLE
Gitignore Claude Code local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,10 @@ prototypes/**/__pycache__/
 
 # Written by `gemini mcp add/remove`, which the CLI integration harness drives.
 .gemini/
+
+# Claude Code local state. settings.local.json is per-developer by convention;
+# a shared settings.json stays committable so team permissions can be checked in.
+# Note the trailing /*: excluding the directory itself would make the negation
+# below unreachable, because git will not descend into an excluded directory.
+.claude/*
+!.claude/settings.json


### PR DESCRIPTION
`.claude/settings.local.json` has sat untracked in the working tree all session. It holds per-developer tool permissions and does not belong in the repository.

## The pattern, and why it is `.claude/*`

```gitignore
.claude/*
!.claude/settings.json
```

Not `.claude/`. Excluding the **directory** makes the negation unreachable — git does not descend into an excluded directory, so a later `!.claude/settings.json` is never considered. My first attempt had exactly that bug.

Using `.claude/*` excludes the *contents* while leaving the directory traversable, so a shared `settings.json` stays committable if the project ever wants checked-in team permissions. That matches Claude Code's convention: `settings.json` shared, `settings.local.json` personal.

## Verified by observing behaviour, not by trusting the tool

`git check-ignore -v` reports negated patterns as matches and exits 0 either way, which made the broken version look correct. Creating the file and reading `git status` settles it:

```
?? .claude/                        shared settings.json is committable
!! .claude/settings.local.json     personal settings stay ignored
!! .claude/settings.local.json.bak
```

Also already covered from earlier work: `.gemini/`, which the CLI integration harness creates when it registers and unregisters the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA