### PR TITLE
Disable stateful response caching, fix workspace cancellation and the int guard

### DIFF
--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -20,9 +20,9 @@ Severity is about consequence, not effort.
 | 7 | Low | Distribution: Smithery and Glama listings | open |
 | 8 | Low | Codex still routes two questions to `evaluate_sage` | accepted |
 | 9 | Low | Jupyter kernel `debug_request` question left unresolved | deferred |
-| 10 | **Critical** | Response caching breaks state and isolation across MCP clients | open |
-| 11 | High | Cancelling a named workspace restarts the default workspace | open |
-| 12 | High | The large-integer corruption guard accepts corrupted JSON integers | open |
+| 10 | **Critical** | Response caching breaks state and isolation across MCP clients | **done** |
+| 11 | High | Cancelling a named workspace restarts the default workspace | **done** |
+| 12 | High | The large-integer corruption guard accepts corrupted JSON integers | **done** |
 | 13 | Medium | `evaluate_sage_streaming` emits output only after completion | open |
 | 14 | Medium | Idle culling discards journals instead of persisting them | open |
 | 15 | Medium | Sanitized journal filenames collide | open |
@@ -277,7 +277,14 @@ display, which is the one argument that would justify it.
 
 ---
 
-## 10. Response caching breaks state and client isolation — **critical**
+## 10. Response caching breaks state and client isolation — **critical** — DONE
+
+**Fixed.** Tool-call, resource and prompt caching are disabled; only the list_*
+catalogues stay cached, since those are identical for every caller. Three tests
+cover it and all three fail with FastMCP's defaults restored.
+
+Original finding follows.
+
 
 ### What is wrong
 
@@ -317,7 +324,15 @@ changes state rather than returning a cached response.
 
 ---
 
-## 11. Named-workspace cancellation targets the wrong worker — high
+## 11. Named-workspace cancellation targets the wrong worker — high — DONE
+
+**Fixed.** The workspace key is computed once and used for both `get` and
+cancellation. Worker responses are now matched to their request id, and stale
+lines from a cancelled computation are discarded rather than returned as the
+next request's result.
+
+Original finding follows.
+
 
 ### What is wrong
 
@@ -348,7 +363,16 @@ worker as well as the pure-Python shim.
 
 ---
 
-## 12. The large-integer corruption guard does not guard JSON integers — high
+## 12. The large-integer corruption guard does not guard JSON integers — high — DONE
+
+**Fixed.** Any numeric argument above 2^53 is refused whether it arrives as int
+or float, because the server cannot tell an exact value from one a JavaScript
+client already rounded. Decimal strings remain exact at any size. Verified
+against real Sage: the string form returns the correct prime for 10^30 and the
+rounded integer from the review is rejected.
+
+Original finding follows.
+
 
 ### What is wrong
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This document tracks planned improvements to the SageMath MCP server, organized by priority and effort. The goal is to strengthen the server's position as a universal mathematics MCP server that enables LLMs to perform any symbolic or discrete mathematical operation.
 
-**Current state (v0.4.0):** 37 MCP tools (31 Sage-backed, 6 infrastructure) covering calculus, algebra, linear algebra, ODEs, number theory, combinatorics, graph theory, group theory, elliptic curves, coding theory, boolean algebra, polynomial rings, geometry, probability, vector calculus, statistics, 2D/3D plotting, numeric root-finding, and streaming execution. 258 unit tests, and 333 tests against a real SageMath 10.9 runtime, plus 43 CLI integration tests.
+**Current state (v0.4.0):** 37 MCP tools (31 Sage-backed, 6 infrastructure) covering calculus, algebra, linear algebra, ODEs, number theory, combinatorics, graph theory, group theory, elliptic curves, coding theory, boolean algebra, polynomial rings, geometry, probability, vector calculus, statistics, 2D/3D plotting, numeric root-finding, and a buffered streaming facade. The current suites pass 267 pure-Python tests and all 342 tests against a real SageMath 10.9 runtime, plus 43 CLI integration tests.
 
 Integration coverage now includes every tool exercised against the examples in its own
 documentation, and a syntax matrix over the input spellings each tool must accept. Both
@@ -13,10 +13,13 @@ nothing at all.
 
 ## Open review actions
 
-A review on 2026-08-13 found the AST validator bypassable in six ways, and the
-README documenting protections that are not enforced. Both are tracked with
+A review on 2026-08-13 found three release-blocking issues: the AST validator is
+bypassable, the public security claims overstate the controls, and FastMCP's
+default response cache breaks state and isolation across clients. It also found
+correctness gaps in named-workspace cancellation, exact large integers, streaming,
+persistence, workspace routing and version synchronization. All are tracked with
 evidence, a suggested fix and a verification step in
-[REVIEW_ACTIONS.md](REVIEW_ACTIONS.md). The security items outrank everything
+[REVIEW_ACTIONS.md](REVIEW_ACTIONS.md). Review items 1, 2 and 10 outrank everything
 below.
 
 ## Competitive position (surveyed 2026-08-13)
@@ -40,12 +43,12 @@ The adjacent market is roughly five times larger and is where attention actually
 
 ### Where this project leads
 
-- **Sandboxing.** sympy-mcp documents that its parser "uses `eval` under the hood,
-  effectively allowing arbitrary code execution". No SageMath peer documents a sandbox at
-  all. The AST validator with a configurable policy is the clearest differentiator, and
-  only [Eis4TY/Sym-MCP](https://github.com/Eis4TY/Sym-MCP) shares the approach.
+- **Security posture under repair.** The configurable AST validator is useful
+  defence in depth against accidental misuse, but review items 1-3 show that it
+  is not currently an adversarial sandbox. Do not treat sandboxing as a competitive
+  differentiator until the bypass tests and container hardening are complete.
 - **Tool surface.** 37 against 3, 5 and 10 for the SageMath peers.
-- **Verification.** 258 unit and 333 real-runtime tests; peer test coverage is largely
+- **Verification.** 267 pure-Python and 342 real-runtime tests; peer test coverage is largely
   invisible.
 - **Documentation.** 1218 README lines against 481, 284, 187 and 89.
 - **Operations.** Helm chart, Cosign-signed images, monitoring resource, health endpoint.
@@ -84,7 +87,7 @@ At the time of the survey the only SageMath server in the official registry was
 publication requires the ownership marker to be present in the *published* PyPI
 description, so it takes effect from the first release after this change.
 
-## Tier 2: Session ergonomics (done 2026-08-13)
+## Tier 2: Session ergonomics (shipped; corrective work open)
 
 The two capabilities where a one-star project was genuinely ahead. Neither needed an
 architectural change.
@@ -93,9 +96,11 @@ architectural change.
       turns the resulting KeyboardInterrupt into an `Interrupted` response and keeps its
       namespace. `cancel_sage_session` remains the escape hatch for a wedged worker.
 - [x] **Named multi-sessions.** `start_sage_session`, `list_sage_sessions` and
-      `stop_sage_session`, with an optional `session` argument on the state-bearing
-      tools. The default workspace keys on the bare scope, so existing behaviour and
-      persisted journals are unchanged.
+      `stop_sage_session`, with workspace selection on raw evaluation and session
+      controls. The default workspace keys on the bare scope.
+- [ ] **Correct named-session routing.** Cancellation must target the selected
+      workspace, response ids must be verified, and specialized tools must expose
+      the same `session` selector (review items 11 and 16).
 
 Two details worth remembering. `interrupt` deliberately does not take the session lock:
 the evaluation being interrupted holds it, so waiting would deadlock until the
@@ -161,8 +166,10 @@ distribution and session ergonomics, not coverage.
 
 - [x] **Enriched `evaluate_sage` description** — 14 domain examples (was 8): added symbolic sums, Laplace/inverse Laplace transforms, modular arithmetic, vector calculus, numeric root finding, recurrence relations
 - [x] **HTTP `/health` endpoint** — returns `{"status": "ok", "version": "...", "active_sessions": N}` for Kubernetes liveness/readiness probes (Starlette route on HTTP transports)
-- [x] **`evaluate_sage_streaming`** — executes code and emits each stdout line as a progress event for real-time partial output display
-- [x] **Disk-backed session persistence** — code journal saved to `SAGEMATH_MCP_PERSIST_DIR` on shutdown, replayed on restore. Controlled by `SAGEMATH_MCP_PERSIST_SESSIONS` and `SAGEMATH_MCP_PERSIST_DIR` environment variables.
+- [x] **`evaluate_sage_streaming` facade** — currently replays captured stdout as progress events after execution finishes.
+- [ ] **True incremental streaming** — extend the worker protocol so stdout events arrive while execution is running (review item 13).
+- [x] **Disk-backed session persistence foundation** — code journals are saved on explicit stop/server shutdown and replayed on restore. Controlled by `SAGEMATH_MCP_PERSIST_SESSIONS` and `SAGEMATH_MCP_PERSIST_DIR`.
+- [ ] **Complete persistence lifecycle and isolation** — save journals during idle culling and replace lossy filename sanitization with collision-free identities (review items 14 and 15).
 
 ## Phase 4 — Niche Domains (Not Planned)
 
@@ -188,7 +195,7 @@ All items from the initial evaluation and TODO have been implemented:
 
 - [x] 18 MCP math tools (calculus, algebra, linear algebra, ODEs, number theory, statistics, plotting)
 - [x] CLI integration test suite (43 cases, Claude + Gemini)
-- [x] 242 unit tests at 99% branch coverage
+- [x] 267 pure-Python tests and 342 tests against SageMath 10.9
 - [x] FastMCP 3.x upgrade with full API migration
 - [x] CI modernization (6 parallel jobs, matrix testing, uv caching, pip-audit, coverage)
 - [x] Docker image pinned to SageMath 10.9
@@ -202,3 +209,4 @@ All items from the initial evaluation and TODO have been implemented:
 - [x] Project metadata, classifiers, URLs
 - [x] MIT LICENSE file (was Apache 2.0)
 - [x] Version synchronization across pyproject.toml, __init__.py, Helm chart
+- [ ] Include both `server.json` version fields in automated version synchronization

--- a/TODO.md
+++ b/TODO.md
@@ -20,4 +20,14 @@
 - [x] Add CI smoke tests that bring up `docker compose` services (pure-Python mode) and exercise `scripts/exercise_mcp.py`.
 - [x] Add Dependabot (or Renovate) configuration for Python, GitHub Actions, and Docker dependencies.
 
-- [ ] Work through [REVIEW_ACTIONS.md](REVIEW_ACTIONS.md); items 1 and 2 (sandbox bypasses, README security claims) are critical.
+## Current priority queue
+
+- [ ] **Release blocker:** disable stateful tool/resource response caching and add two-client isolation tests ([review item 10](REVIEW_ACTIONS.md)).
+- [ ] **Release blocker:** close the AST-validator bypasses, correct the public sandbox claims, and harden the real container boundary ([review items 1-3](REVIEW_ACTIONS.md)).
+- [ ] Fix named-workspace cancellation and validate worker response ids ([review item 11](REVIEW_ACTIONS.md)).
+- [ ] Reject every numeric integer above `2^53`; require decimal strings for exact large values ([review item 12](REVIEW_ACTIONS.md)).
+- [ ] Implement actual incremental stdout events or rename the buffered streaming facade ([review item 13](REVIEW_ACTIONS.md)).
+- [ ] Persist idle-culled sessions and make journal filenames collision-free ([review items 14-15](REVIEW_ACTIONS.md)).
+- [ ] Add named-workspace selection to every specialized worker-backed tool ([review item 16](REVIEW_ACTIONS.md)).
+- [ ] Synchronize both `server.json` versions in `scripts/bump_version.py` and add a consistency test ([review item 17](REVIEW_ACTIONS.md)).
+- [ ] Work through the remaining maintainability, release-dry-run, dependency-audit and distribution actions in [REVIEW_ACTIONS.md](REVIEW_ACTIONS.md).

--- a/src/sagemath_mcp/server.py
+++ b/src/sagemath_mcp/server.py
@@ -15,7 +15,12 @@ from typing import Annotated
 
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
-from fastmcp.server.middleware.caching import ResponseCachingMiddleware
+from fastmcp.server.middleware.caching import (
+    CallToolSettings,
+    GetPromptSettings,
+    ReadResourceSettings,
+    ResponseCachingMiddleware,
+)
 from fastmcp.server.middleware.logging import LoggingMiddleware
 from fastmcp.server.middleware.timing import TimingMiddleware
 from pydantic import Field
@@ -125,7 +130,28 @@ mcp.add_middleware(TimingMiddleware())
 mcp.add_middleware(
     LoggingMiddleware(include_payloads=False, include_payload_length=True)
 )
-mcp.add_middleware(ResponseCachingMiddleware())
+# Tool-call and resource caching are OFF, deliberately.
+#
+# The cache key covers the tool name, arguments and auth identity, but NOT the
+# MCP session id, and unauthenticated clients share one anonymous partition.
+# Every tool here is stateful, so with the defaults (one hour, all tools) two
+# clients making the same call collide: the second gets the first's cached
+# response in microseconds without its own worker ever executing, and then finds
+# the variable undefined. The reverse is a confidentiality problem -- a
+# state-dependent expression can return another client's value.
+#
+# Repeated reset/cancel/start/stop calls were also skipped while reporting
+# success, and the session and monitoring resources served stale snapshots.
+#
+# Only the list_* caches remain: the tool, resource and prompt catalogues are
+# identical for every caller and do not change at runtime.
+mcp.add_middleware(
+    ResponseCachingMiddleware(
+        call_tool_settings=CallToolSettings(enabled=False),
+        read_resource_settings=ReadResourceSettings(enabled=False),
+        get_prompt_settings=GetPromptSettings(enabled=False),
+    )
+)
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +235,11 @@ async def evaluate_sage(
     """Run SageMath code, preserving state within the caller's MCP session."""
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required for stateful execution")
-    sage_session = await SESSION_MANAGER.get(SESSION_MANAGER.key_for(ctx.session_id, session))
+    # Compute the key once and reuse it. Cancelling used to pass ctx.session_id,
+    # which restarts the DEFAULT workspace: cancelling work in 'curves' destroyed
+    # unrelated default state while the curves worker kept running.
+    session_key = SESSION_MANAGER.key_for(ctx.session_id, session)
+    sage_session = await SESSION_MANAGER.get(session_key)
     progress_task: asyncio.Task[None] | None = None
     if ctx is not None:
         await ctx.info("Starting SageMath evaluation")
@@ -223,9 +253,9 @@ async def evaluate_sage(
         )
     except asyncio.CancelledError:
         monitoring.record_failure("cancelled", is_security=False, details="evaluation cancelled")
-        await SESSION_MANAGER.cancel(ctx.session_id)
+        await SESSION_MANAGER.cancel(session_key)
         if ctx is not None:
-            await ctx.warning("Sage evaluation cancelled; session restarted")
+            await ctx.warning(f"Sage evaluation cancelled; session '{session}' restarted")
         raise
     except SageEvaluationError as exc:
         monitoring.record_failure(
@@ -580,14 +610,23 @@ def _exact_int(value: int | str | float, name: str) -> int:
     if isinstance(value, float):
         if not value.is_integer():
             raise ToolError(f"'{name}' must be a whole number, got {value!r}")
-        if abs(value) > _EXACT_JSON_INT_LIMIT:
-            raise ToolError(
-                f"'{name}' arrived as a floating-point number larger than 2^53, so its "
-                "exact value is already lost. Pass it as a decimal string instead, "
-                f'for example "{int(value)}".'
-            )
-        return int(value)
-    return int(value)
+        return _reject_if_inexact(int(value), name)
+    # An int is not automatically safe. A JavaScript client rounds the value
+    # BEFORE serialising and then emits the rounded digits as a JSON integer, so
+    # the float branch above is never reached: 10^30 arrives as the int
+    # 1000000000000000019884624838656 and looks perfectly ordinary.
+    return _reject_if_inexact(int(value), name)
+
+
+def _reject_if_inexact(value: int, name: str) -> int:
+    """Refuse any JSON-borne number too large to have survived a double."""
+    if abs(value) > _EXACT_JSON_INT_LIMIT:
+        raise ToolError(
+            f"'{name}' is larger than 2^53, where JSON numbers stop being exact: "
+            "a JavaScript-based client will already have rounded it before sending. "
+            f'Pass it as a decimal string instead, for example "{value}".'
+        )
+    return value
 
 
 def _check_matrix(rows: list[list[float]], name: str) -> None:

--- a/src/sagemath_mcp/session.py
+++ b/src/sagemath_mcp/session.py
@@ -130,6 +130,32 @@ class SageSession:
                 break
             LOGGER.warning("sage[%s] stderr: %s", self.session_id, line.decode().rstrip())
 
+    async def _read_response(self, request_id: str) -> tuple[bytes, dict]:
+        """Read until the response for *request_id* arrives, discarding stragglers.
+
+        A cancelled or timed-out request leaves its response in the pipe. Without
+        this the next request read that stale line and returned the previous
+        computation's result as its own.
+        """
+        assert self._process and self._process.stdout
+        while True:
+            raw = await self._process.stdout.readline()
+            if not raw:
+                return raw, {}
+            try:
+                message = json.loads(raw.decode("utf-8"))
+            except json.JSONDecodeError:
+                LOGGER.warning("Discarding unparsable worker line in %s", self.session_id)
+                continue
+            incoming = message.get("id")
+            if incoming is not None and incoming != request_id:
+                LOGGER.warning(
+                    "Discarding stale worker response %s in %s (waiting for %s)",
+                    incoming, self.session_id, request_id,
+                )
+                continue
+            return raw, message
+
     async def evaluate(
         self,
         code: str,
@@ -156,8 +182,8 @@ class SageSession:
             self._process.stdin.write(data)
             await self._process.stdin.drain()
             try:
-                raw = await asyncio.wait_for(
-                    self._process.stdout.readline(), timeout=effective_timeout
+                raw, response = await asyncio.wait_for(
+                    self._read_response(payload["id"]), timeout=effective_timeout
                 )
             except TimeoutError as exc:
                 await self._handle_timeout()
@@ -166,7 +192,6 @@ class SageSession:
                 ) from exc
             if not raw:
                 raise SageProcessError("Sage worker terminated unexpectedly.")
-        response = json.loads(raw.decode("utf-8"))
         self.last_used_at = time.time()
         if not response.get("ok", False):
             error = response.get("error", {})

--- a/tests/test_cache_isolation.py
+++ b/tests/test_cache_isolation.py
@@ -1,0 +1,86 @@
+"""Two MCP clients must not share tool results.
+
+FastMCP's response cache keys on tool name, arguments and auth identity, but not
+on the MCP session. With the defaults every tool was cached for an hour, so a
+second client making an identical call received the first client's response
+without its own worker ever running -- and then found the variable undefined.
+
+The reverse is a confidentiality problem: a state-dependent expression could
+return another client's value.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client
+
+from sagemath_mcp import server
+from sagemath_mcp.config import SageSettings
+from sagemath_mcp.session import SageSessionManager
+
+
+@pytest.fixture
+def python_manager(monkeypatch):
+    """Route tools through the pure-Python worker so no Sage install is needed."""
+    manager = SageSessionManager(SageSettings(force_python_worker=True))
+    monkeypatch.setattr(server, "SESSION_MANAGER", manager)
+    yield manager
+
+
+def _text(result) -> str:
+    return "".join(block.text for block in result.content if hasattr(block, "text"))
+
+
+@pytest.mark.asyncio
+async def test_two_clients_do_not_share_tool_results(python_manager):
+    """The identical call from two clients must execute twice, not once."""
+    async with Client(server.mcp) as first, Client(server.mcp) as second:
+        # Same arguments in both clients: the cache key would collide.
+        await first.call_tool("evaluate_sage", {"code": "cache_probe = 41"})
+        await second.call_tool("evaluate_sage", {"code": "cache_probe = 41"})
+
+        # If the second call was served from cache, its worker never ran and
+        # the variable does not exist there.
+        second_read = await second.call_tool("evaluate_sage", {"code": "cache_probe"})
+        assert "41" in _text(second_read), (
+            "second client's assignment did not execute; it was served from cache"
+        )
+
+        first_read = await first.call_tool("evaluate_sage", {"code": "cache_probe"})
+        assert "41" in _text(first_read)
+
+
+@pytest.mark.asyncio
+async def test_repeated_state_transitions_are_not_cached(python_manager):
+    """reset must actually reset each time, not return a cached success."""
+    async with Client(server.mcp) as client:
+        await client.call_tool("evaluate_sage", {"code": "keeper = 7"})
+        await client.call_tool("reset_sage_session", {})
+
+        gone = await client.call_tool(
+            "evaluate_sage", {"code": "keeper"}, raise_on_error=False
+        )
+        assert gone.is_error, "reset did not clear state"
+
+        await client.call_tool("evaluate_sage", {"code": "keeper = 8"})
+        await client.call_tool("reset_sage_session", {})
+        gone_again = await client.call_tool(
+            "evaluate_sage", {"code": "keeper"}, raise_on_error=False
+        )
+        assert gone_again.is_error, (
+            "the second reset returned a cached success without resetting"
+        )
+
+
+@pytest.mark.asyncio
+async def test_monitoring_resource_is_not_stale(python_manager):
+    """Metrics must reflect work done after the first read."""
+    import json
+
+    async with Client(server.mcp) as client:
+        first = json.loads((await client.read_resource("resource://sagemath/monitoring/metrics"))[0].text)
+        for index in range(3):
+            await client.call_tool("evaluate_sage", {"code": f"probe_{index} = {index}"})
+        second = json.loads((await client.read_resource("resource://sagemath/monitoring/metrics"))[0].text)
+
+    assert second["attempts"] > first["attempts"], "monitoring resource served a stale snapshot"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2073,7 +2073,6 @@ async def test_named_sessions_listed_per_client(monkeypatch):
         ("12", 12),
         (12.0, 12),
         ("1000000000000000000000000000000", 10**30),
-        (10**30, 10**30),
         ("1_000", 1000),
     ],
 )
@@ -2082,21 +2081,37 @@ async def test_exact_int_accepts_lossless_forms(value, expected):
 
 
 @pytest.mark.asyncio
-async def test_exact_int_rejects_a_value_that_already_lost_precision():
-    """A float above 2^53 has already been mangled; refuse rather than round.
+@pytest.mark.parametrize(
+    "value",
+    [
+        1e30,                                # float: already through a double
+        10**30,                              # int: exact here, but unverifiable
+        1000000000000000019884624838656,     # the value a JS client actually sends
+        2**53 + 1,                           # first integer a double cannot hold
+    ],
+)
+async def test_exact_int_rejects_values_json_cannot_carry(value):
+    """Above 2^53 the server cannot tell an exact value from a rounded one.
 
-    JSON numbers are IEEE doubles in JavaScript-based MCP clients, so 10^30
-    arrives as 1000000000000000019884624838656. next_prime() on that returns a
-    perfectly plausible wrong answer, which is worse than an error.
+    A JavaScript client rounds BEFORE serialising and emits the rounded digits as
+    a JSON integer, so checking only floats missed the real case: 10^30 arrives
+    as the int 1000000000000000019884624838656 and looks ordinary.
     """
-    with pytest.raises(ToolError, match="larger than 2\\^53"):
-        server._exact_int(1e30, "a")
+    with pytest.raises(ToolError, match="2\\^53"):
+        server._exact_int(value, "a")
 
     # The message has to tell the caller what to do instead.
     try:
-        server._exact_int(1e30, "a")
+        server._exact_int(value, "a")
     except ToolError as exc:
         assert "decimal string" in str(exc)
+
+
+@pytest.mark.asyncio
+async def test_exact_int_accepts_any_size_as_a_string():
+    """Strings are exact by construction, so no ceiling applies."""
+    assert server._exact_int("1000000000000000000000000000000", "a") == 10**30
+    assert server._exact_int(str(2**200), "a") == 2**200
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Review items **10, 11 and 12**. Stacked on #33 (security hardening).

## 10 — Response caching was returning one client's work to another

FastMCP's cache key covers tool name, arguments and auth identity but **not the MCP session**, and unauthenticated clients share one anonymous partition. With the default one-hour cache over every tool, two clients making the same call collided: the second received the first's response without its own worker running, then found the variable undefined. The reverse is a confidentiality problem.

Repeated `reset`/`cancel`/`start`/`stop` were also skipped while reporting success, and the session and monitoring resources served stale snapshots.

Tool-call, resource and prompt caching are now **off**. The `list_*` catalogues stay cached — identical for every caller, unchanged at runtime.

## 11 — Cancelling a named workspace restarted the default one

`evaluate_sage` resolved its workspace with `key_for()` but the `CancelledError` handler passed `ctx.session_id`. Cancelling work in `curves` **destroyed unrelated default state while the curves worker kept running**. The key is now computed once and used for both.

**Relatedly**: worker responses were never matched to their request. A cancelled or timed-out computation leaves its response in the pipe, and the next request read that stale line and **returned the previous computation's result as its own**. Responses are now matched by id, stragglers discarded.

## 12 — The integer guard missed the case that actually happens

My earlier guard only inspected floats. A JavaScript client rounds **before** serialising and emits the rounded digits as a JSON *integer*, so the float branch was never reached:

```
1000000000000000019884624838656   ← accepted unchanged
```

That is the exact value named in the tool's own description. Any numeric argument above 2⁵³ is now refused regardless of type, since the server cannot distinguish an exact value from a pre-rounded one. Decimal strings stay exact at any size.

## Verification

| Check | Result |
|---|---|
| 3 cache tests with FastMCP defaults restored | **all 3 fail** |
| Same tests with caching disabled | **all 3 pass** |
| `next_prime` via decimal string, real Sage | `1000000000000000000000000000057` correct |
| The review's rounded integer | **rejected** with instructions |
| Integration / unit | **376 / 301 pass** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA