### PR TITLE
Add a release dry run and a scheduled dependency audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,62 @@
+name: Scheduled audit
+
+# pip-audit is blocking in CI, which is deliberate: a known-vulnerable
+# dependency should stop a merge. The side effect is that a new upstream
+# advisory turns someone's unrelated pull request red, with no change of theirs
+# to blame. This runs the same audit against main on a schedule so an advisory
+# is found on its own timetable, and opens an issue rather than ambushing a
+# contributor.
+
+on:
+  schedule:
+    # Mondays, 07:00 UTC.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.0
+        with:
+          enable-cache: true
+      - name: Create virtual environment
+        run: uv venv
+      - name: Install dependencies
+        run: uv pip install -e .[dev]
+      - name: Audit dependencies
+        id: audit
+        # Do not fail the job here: the report is wanted either way, and the
+        # issue below is more useful than a red schedule nobody is watching.
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          uv run pip-audit --skip-editable --desc | tee audit-report.txt
+      - name: Open an issue when something is found
+        if: steps.audit.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="Dependency advisory found by the scheduled audit"
+          # One open issue at a time; append rather than pile up duplicates.
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number // empty')
+          BODY=$(printf '%s\n\n```\n%s\n```\n' \
+            "The weekly audit found advisories against \`main\`. CI blocks on pip-audit, so this will also fail any open pull request until the lock is updated (\`uv lock --upgrade\`)." \
+            "$(head -60 audit-report.txt)")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY"
+          fi
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: audit-report
+          path: audit-report.txt
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,15 @@ on:
   push:
     tags:
       - "v*"
+  # The registry and release jobs otherwise run for the first time during a real
+  # release, which is a poor place to discover a typo. This exercises both
+  # without publishing anything.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Validate the publish paths without publishing"
+        type: boolean
+        default: true
 
 jobs:
   test:
@@ -100,6 +109,8 @@ jobs:
 
   publish:
     needs: [build, docker, helm]
+    # PyPI is irreversible; never reachable from a manual dispatch.
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -120,6 +131,13 @@ jobs:
   # published PyPI description, so this can only run once the package is live.
   mcp-registry:
     needs: [publish]
+    # On a tag, still gated on a successful PyPI publish so a release object can
+    # never announce a version that was not shipped. On a manual dispatch,
+    # publish is skipped and this runs anyway in dry-run mode.
+    if: >-
+      always() &&
+      ((startsWith(github.ref, 'refs/tags/v') && needs.publish.result == 'success')
+       || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       id-token: write   # OIDC, so no long-lived registry token is stored
@@ -129,6 +147,7 @@ jobs:
       - name: Align server.json with the tag
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${VERSION:-0.0.0-dryrun}"
           jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' \
             server.json > server.tmp && mv server.tmp server.json
           cat server.json
@@ -137,9 +156,18 @@ jobs:
           curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
             | tar xz mcp-publisher
       - name: Publish to the MCP registry
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           ./mcp-publisher login github-oidc
           ./mcp-publisher publish
+      - name: Dry run - validate the manifest and login only
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          python3 -c "import json,sys; d=json.load(open('server.json')); \
+            assert d['name'] and d['version'] and d['packages'], 'server.json incomplete'; \
+            print('server.json parses:', d['name'], d['version'])"
+          ./mcp-publisher login github-oidc
+          echo "Dry run: authenticated successfully, not publishing."
 
   # Runs last so a failed publish cannot leave a release announcing a version
   # that was never shipped. Until this existed, every release object was created
@@ -147,6 +175,13 @@ jobs:
   # v0.3.1 as Latest -- which is also where pyproject points its Changelog URL.
   github-release:
     needs: [publish]
+    # On a tag, still gated on a successful PyPI publish so a release object can
+    # never announce a version that was not shipped. On a manual dispatch,
+    # publish is skipped and this runs anyway in dry-run mode.
+    if: >-
+      always() &&
+      ((startsWith(github.ref, 'refs/tags/v') && needs.publish.result == 'success')
+       || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -177,7 +212,13 @@ jobs:
             echo "::warning::No CHANGELOG.md entry for ${VERSION}; using generated notes."
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Dry run - render the notes without creating a release
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          echo "Would create a release with these notes:"
+          head -40 release-notes.md || echo "(no changelog entry; generated notes would be used)"
       - name: Create the GitHub release
+        if: startsWith(github.ref, 'refs/tags/v')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -15,8 +15,8 @@ Severity is about consequence, not effort.
 | 2 | **Critical** | README documents protections that do not exist | **done** |
 | 3 | High | The container, not the validator, is the real boundary — and it is not hardened | **done** |
 | 4 | Medium | `server.py` is 2147 lines and the least-covered module | open |
-| 5 | Medium | Two release paths cannot be exercised before a tag push | open |
-| 6 | Low | 104 dependencies, with pip-audit now blocking | open |
+| 5 | Medium | Two release paths cannot be exercised before a tag push | **done** |
+| 6 | Low | 104 dependencies, with pip-audit now blocking | **done** |
 | 7 | Low | Distribution: Smithery and Glama listings | open |
 | 8 | Low | Codex still routes two questions to `evaluate_sage` | accepted |
 | 9 | Low | Jupyter kernel `debug_request` question left unresolved | deferred |
@@ -214,7 +214,21 @@ documented example, and all 342 tests stay green against SageMath 10.9.
 
 ---
 
-## 5. Two release paths cannot be exercised before a tag push — medium
+## 5. Two release paths cannot be exercised before a tag push — medium — DONE
+
+**Fixed.** `release.yml` accepts a `workflow_dispatch` that exercises the
+registry and release jobs without publishing: the manifest is parsed, OIDC login
+is performed, and the release notes are rendered but nothing is created. PyPI is
+unreachable from a dispatch.
+
+The tag ordering is preserved deliberately. Both jobs still declare
+`needs: [publish]` and gate on `needs.publish.result == 'success'` for tags, so a
+failed upload still cannot leave a release announcing a version that was never
+shipped. Changing `needs` to `[build]` would have been simpler and would have
+silently removed that guarantee.
+
+Original finding follows.
+
 
 `release.yml`'s `mcp-registry` and `github-release` jobs only run on `v*` tags,
 so their first execution is a real release. The registry job additionally depends
@@ -231,7 +245,15 @@ publishing anything.
 
 ---
 
-## 6. 104 dependencies, with pip-audit now blocking — low
+## 6. 104 dependencies, with pip-audit now blocking — low — DONE
+
+**Fixed.** `audit.yml` runs the same audit against `main` every Monday and opens
+(or comments on) a single issue when something is found, so an advisory arrives
+on its own schedule instead of turning a contributor's unrelated pull request
+red with no change of theirs to blame. CI stays blocking.
+
+Original finding follows.
+
 
 Making `pip-audit` blocking was right, and it immediately cleared 32 findings.
 The consequence is that a new upstream advisory now turns CI red with no change


### PR DESCRIPTION
Review items **5 and 6**. Stacked on #35.

## 5 — The release paths can now be exercised before a release

`release.yml` accepts a `workflow_dispatch` that runs the registry and GitHub-release jobs **without publishing**: the manifest is parsed, OIDC login is performed, the release notes are rendered — and nothing is created. PyPI is unreachable from a dispatch.

**The tag ordering is deliberately preserved.** Both jobs still declare `needs: [publish]` and gate on `needs.publish.result == 'success'` for tags.

The simpler change — pointing them at `[build]` so they'd run on dispatch — is what I wrote first, and it silently removed the guarantee that a failed upload cannot leave a release announcing a version that was never shipped. I caught it reading the job graph back. The more awkward `always() && (...)` condition is worth it.

## 6 — Advisories arrive on their own schedule

`pip-audit` stays blocking in CI, which is right: a known-vulnerable dependency should stop a merge. The side effect is that a **new upstream advisory turns someone's unrelated PR red with no change of theirs to blame**.

`audit.yml` runs the same audit against `main` every Monday and opens — or comments on — a single tracking issue.

## Verification

Both workflows parse; the job graph keeps `publish` gated to tags; every `run` block passes `bash -n`.

Neither path can be fully proven until a dispatch is triggered, which is exactly the gap item 5 exists to close — so triggering it once after merge is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA