### PR TITLE
Add the Smithery listing configuration

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -53,8 +53,9 @@ docker pull ghcr.io/xbp-europe/sagemath-mcp:latest
 ```
 
 Images inherit the upstream `sagemath/sagemath` base and run as the non-root `sage`
-user (UID/GID 1001). Ensure repository directories mounted into the container are
-writable by that user (`chown -R 1001:1001 .` before `docker run`/`docker compose up`).
+user (UID/GID 1001), with a read-only root filesystem and writable scratch supplied
+as tmpfs. Mounted repository directories are read-only and need no ownership change;
+grant UID/GID 1001 write access only to a dedicated persistence volume, if you use one.
 
 This number comes from the base image and is not ours to choose: `sage` was UID 1000
 through SageMath 10.5 and is 1001 from 10.9. Check it after any base image bump with

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -25,9 +25,14 @@ cd sagemath-mcp
 docker compose up --build
 ```
 
-The container exposes `http://127.0.0.1:8314/mcp` and runs as the non-root `sage` user (UID/GID 1001).
-If you mount the repository from the host, ensure it is writable by that UID (`chown -R 1001:1001 .`
-before launching).
+The container exposes `http://127.0.0.1:8314/mcp` and runs as the non-root `sage` user (UID/GID 1001),
+with a read-only root filesystem.
+
+The bundled compose file mounts the repository read-only, so it needs no ownership
+change. Do **not** `chown -R` the checkout to make it writable: the server runs from
+the package installed in the image, not from the mount, and a writable checkout is
+something an escaped process can edit. If you deliberately develop against the mount,
+drop the `:ro` on that one volume rather than changing ownership of the tree.
 
 ### Kubernetes (Helm)
 
@@ -104,7 +109,8 @@ make test
   docker exec -it sage-mcp bash
   docker rm -f sage-mcp
   ```
-- When mounting directories into Docker or running via `docker compose`, ensure the host path is
-  writable by UID/GID 1001 to satisfy the non-root `sage` user (e.g., `sudo chown -R 1001:1001 <path>`).
+- Only a dedicated persistence or scratch volume should ever be writable, and only that
+  path needs to belong to UID/GID 1001 (`chown 1001:1001 <that-path>`). The checkout
+  itself is mounted read-only by design; do not widen it to fix a permission error.
 - Security policy errors (e.g., "Import statements are disabled") typically indicate unsupported
   operations; rewrite the Sage code using whitelisted modules or helper tools.

--- a/README.md
+++ b/README.md
@@ -739,10 +739,19 @@ All code --- whether from `evaluate_sage` or generated internally by helper tool
 > This section was previously inaccurate: it claimed `subprocess.*`, `pathlib.*`
 > and `socket.*` were blocked when none of them were, because a rule required a
 > module *and* a specific attribute name to match. Seven further bypasses were
-> found and closed at the same time. The table below is now covered by a test
-> that fails if the code stops enforcing it.
+> found and closed at the same time. It was inaccurate a second time, more
+> subtly: the forbidden names were rejected only where they were *called*, so
+> `f = open` followed by `f("/etc/passwd")` passed --- through the specialised
+> tools as well as `evaluate_sage`. Forbidden names are now rejected wherever
+> they are read, and the worker's namespace no longer contains them at all.
+> The table below is covered by a test that fails if the code stops enforcing
+> it, and that test now checks aliases, not just call sites.
 
 **What is blocked:**
+
+Names in the first three rows are rejected **anywhere they are read** --- called,
+assigned, aliased, defaulted into a `lambda`, or placed in a list --- not only in
+call position.
 
 | Category | Details |
 |----------|---------|
@@ -753,6 +762,7 @@ All code --- whether from `evaluate_sage` or generated internally by helper tool
 | Forbidden modules | **Every** attribute of `os`, `sys`, `subprocess`, `shutil`, `socket`, `pathlib`, `builtins` --- at any depth, so `sage.misc.temporary_file.os` is caught too |
 | Unauthorized imports | All imports except those in the allowlist (see below) |
 | Scope manipulation | `global` and `nonlocal` statements (configurable) |
+| Namespace removal | The worker's `__builtins__` omits `open`, `eval`, `exec`, `compile`, `input`, `breakpoint`, `globals`, `locals`, `vars`, `memoryview`, `help`, `exit` and `quit` outright --- a backstop for spellings the AST pass misses. `__import__` deliberately stays, because Sage imports lazily during ordinary mathematics; it is unreachable from caller code, which cannot name any dunder. |
 
 Caller-supplied expressions passed to the specialised tools are validated as
 expressions in their own right before they are embedded in generated code.

--- a/README.md
+++ b/README.md
@@ -785,6 +785,8 @@ actually contains it, so `docker-compose.yml` sets:
 
 | Setting | Why |
 |---------|-----|
+| `read_only: true` | The root filesystem is immutable. Sage needs only a writable temp dir and its own dot-directory, supplied as the two `tmpfs` mounts below; without them it fails outright, which is how they were sized. |
+| `tmpfs: /tmp`, `/home/sage/.sage` | The only writable paths, in memory, capped at 512 MB and 256 MB. |
 | `./:/workspace:ro` | The server runs from the package installed in the image; an escaped process should not be able to edit the checkout it reads. |
 | `cap_drop: [ALL]` | No Linux capabilities are needed to do mathematics. |
 | `security_opt: [no-new-privileges:true]` | Blocks privilege escalation via setuid binaries. |
@@ -796,7 +798,12 @@ checkout and opening outbound sockets. If the server is exposed to untrusted
 callers, also consider `network_mode: none` where the workload allows it, and
 avoid passing secrets in the environment of this container.
 
-The Helm chart applies the equivalent `securityContext`.
+The Helm chart applies `runAsNonRoot`, `allowPrivilegeEscalation: false`,
+`capabilities.drop: [ALL]` and `readOnlyRootFilesystem: true`, with `emptyDir`
+volumes for the same two writable paths and default CPU/memory requests and
+limits. It is close but not identical: compose's `pids_limit` has no direct
+chart equivalent (pod PID limits are a kubelet setting), so set one on the node
+if you need it.
 
 **Enforced limits:**
 

--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -17,7 +17,7 @@ Severity is about consequence, not effort.
 | 4 | Medium | `server.py` is 2147 lines and the least-covered module | open |
 | 5 | Medium | Two release paths cannot be exercised before a tag push | **done** |
 | 6 | Low | 104 dependencies, with pip-audit now blocking | **done** |
-| 7 | Low | Distribution: Smithery and Glama listings | open |
+| 7 | Low | Distribution: Smithery and Glama listings | **partly done** |
 | 8 | Low | Codex still routes two questions to `evaluate_sage` | accepted |
 | 9 | Low | Jupyter kernel `debug_request` question left unresolved | deferred |
 | 10 | **Critical** | Response caching breaks state and isolation across MCP clients | **done** |
@@ -265,7 +265,29 @@ in whoever's PR happens to be open. Keep the blocking behaviour.
 
 ---
 
-## 7. Distribution: Smithery and Glama listings — low
+## 7. Distribution: Smithery and Glama listings — low — PARTLY DONE
+
+**The half that lives in git is done.** `smithery.yaml` declares the stdio launch
+command and the four settings worth exposing, and it names the `sagemath-mcp`
+entry point that `pyproject.toml` actually defines.
+
+**The remaining half needs an account and cannot be automated from here.**
+
+- **Smithery**: connect the repository at <https://smithery.ai/new> with an
+  account that owns `XBP-Europe/sagemath-mcp`. It reads `smithery.yaml` from the
+  default branch.
+- **Glama**: indexes public MCP servers from GitHub automatically and ranks on
+  metadata quality. The repository topics, description and README added earlier
+  are what it reads; claim the listing at <https://glama.ai/mcp/servers> to edit
+  it.
+
+Note that SageMath is a large runtime and is not bundled: the Smithery command
+assumes `sage` is on PATH, so the container image remains the better route for
+callers who do not have it. Worth saying on the listing rather than leaving
+people to discover it.
+
+Original finding follows.
+
 
 The remaining Tier 1 item from the competitive survey. `fermat-mcp` carries both
 badges and has 20 stars against our 12 with a far smaller tool surface.

--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -9,6 +9,11 @@ called out explicitly below.
 
 Severity is about consequence, not effort.
 
+**Second review round.** A re-check found items 1, 2, 3, 11 and 15 partial and
+item 1 still exploitable. What was missing in each is recorded in that item's
+section, under a "second round" heading, along with what closed it. Items 10,
+12, 13, 14, 16 and 17 were confirmed complete.
+
 | # | Severity | Item | Status |
 |---|----------|------|--------|
 | 1 | **Critical** | The AST validator is bypassable in at least seven ways | **done** |
@@ -181,6 +186,20 @@ class of drift impossible to reintroduce silently.
 ---
 
 ## 3. The container is the real boundary, and it is not hardened — high — DONE
+
+**Second round.** The first pass added `cap_drop`, `no-new-privileges`,
+`pids_limit`, `mem_limit` and the read-only mount, but left the root filesystem
+writable, the Helm chart without a read-only root or resource limits, and three
+documents still recommending `chown -R 1001:1001 .`. Now: `read_only: true` with
+tmpfs for `/tmp` and `/home/sage/.sage` (verified by running Sage, a real
+evaluation and a plot under it — without the tmpfs mounts the container fails
+with "No usable temporary directory found", which is how they were sized);
+`readOnlyRootFilesystem`, `emptyDir` scratch and default CPU/memory
+requests/limits in the chart; and the blanket-chown guidance replaced in
+INSTALLATION.md, DISTRIBUTION.md and USAGE.md with "only a dedicated persistence
+volume should be writable". The README no longer claims Helm is "equivalent" —
+it lists what the chart sets and names the one gap (`pids_limit` has no chart
+equivalent).
 
 **Fixed.** The compose stack now mounts the checkout read-only, drops all
 capabilities, sets no-new-privileges, and bounds pids and memory. Verified by
@@ -395,6 +414,16 @@ changes state rather than returning a cached response.
 ---
 
 ## 11. Named-workspace cancellation targets the wrong worker — high — DONE
+
+**Second round.** Evaluation used `_read_response`, but `reset()` still read the
+next line unconditionally, so it consumed a cancelled evaluation's response and
+reported "Failed to reset Sage session" for a reset that had worked. `reset()`
+now matches ids too, an id-less line is no longer accepted as any request's
+answer, and cancellation cleanup moved into `SageSession.evaluate` so streaming
+and the specialised tools stop abandoning a running computation. The strict id
+rule needed a bound — waiting for a matching id is unbounded when the peer
+repeats itself, and a stubbed worker spun there until the process ran out of
+memory — so it gives up after 64 non-matching lines.
 
 **Fixed.** The workspace key is computed once and used for both `get` and
 cancellation. Worker responses are now matched to their request id, and stale

--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -33,6 +33,24 @@ Severity is about consequence, not effort.
 
 ## 1. The AST validator is bypassable — **critical** — DONE
 
+**Reopened once, now closed.** The first fix rejected forbidden names only where
+they were the direct target of an `ast.Call`, so aliasing walked through both raw
+`evaluate_sage` and the specialised tools: `f = open` then `f("/etc/passwd")`,
+`(lambda f=open: f("/etc/passwd").readline())()` and `[open][0](...)` all
+succeeded against real SageMath — the lambda payload returned the first line of
+`/etc/passwd` via `calculate_expression`. Two changes closed it:
+
+1. `security.py` now rejects a forbidden name in **any load context**, not just
+   call position.
+2. `_sage_worker.py` builds user code's `__builtins__` without the dangerous
+   names at all, so a missed spelling has nothing to reach. `__import__` stays —
+   Sage imports lazily during ordinary mathematics — and is unreachable anyway
+   because no dunder can be named.
+
+Eleven aliasing payloads were added to `tests/test_security_bypass.py` (38 tests
+total), each confirmed failing before the fix and passing after, and re-verified
+against real Sage rather than the pure-Python shim.
+
 **Fixed.** An eighth bypass was found while fixing the seven listed: every
 specialised tool `sage_eval`s its caller's expression, so
 `calculate_expression("__import__('os').getuid()")` returned the container uid.
@@ -107,6 +125,14 @@ integration suite to confirm nothing legitimate broke.
 ---
 
 ## 2. README documents protections that do not exist — **critical** — DONE
+
+**Reopened with item 1, now closed.** While the validator only checked call
+position, the README's claim that `open()` and the indirection helpers were
+blocked overstated enforcement — and the consistency test agreed with it, because
+it too probed only the `name('x')` spelling. The table now states that forbidden
+names are rejected wherever they are *read*, documents the restricted worker
+builtins, and the test probes alias assignment, `lambda` defaults and container
+literals for every documented name.
 
 **Fixed.** The table now states what is enforced, and says plainly that the
 validator is defence in depth rather than a boundary. Two tests keep it honest:
@@ -514,6 +540,13 @@ then obtain the same session again and assert that the variable is restored.
 full key, so distinct workspaces cannot share a file. Tests cover slashes,
 question marks, colons, spaces, backslashes, Unicode, existing underscores and
 over-long names.
+
+**Follow-up:** the rename orphaned every journal written by an earlier version,
+including plain default sessions. `existing_journal_path()` falls back to the two
+previous filename schemes when no digest-named journal exists, and
+`save_journal()` retires the legacy file once state has been written under the
+new name, so the two schemes cannot diverge. Covered by a lookup test and an
+end-to-end restore-and-migrate test.
 
 Original finding follows.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This document tracks planned improvements to the SageMath MCP server, organized by priority and effort. The goal is to strengthen the server's position as a universal mathematics MCP server that enables LLMs to perform any symbolic or discrete mathematical operation.
 
-**Current state (v0.4.0):** 37 MCP tools (31 Sage-backed, 6 infrastructure) covering calculus, algebra, linear algebra, ODEs, number theory, combinatorics, graph theory, group theory, elliptic curves, coding theory, boolean algebra, polynomial rings, geometry, probability, vector calculus, statistics, 2D/3D plotting, numeric root-finding, and a buffered streaming facade. The current suites pass 267 pure-Python tests and all 342 tests against a real SageMath 10.9 runtime, plus 43 CLI integration tests.
+**Current state (v0.4.0):** 37 MCP tools (31 Sage-backed, 6 infrastructure) covering calculus, algebra, linear algebra, ODEs, number theory, combinatorics, graph theory, group theory, elliptic curves, coding theory, boolean algebra, polynomial rings, geometry, probability, vector calculus, statistics, 2D/3D plotting, numeric root-finding, and incremental streaming. The current suites pass 267 pure-Python tests and all 342 tests against a real SageMath 10.9 runtime, plus 43 CLI integration tests.
 
 Integration coverage now includes every tool exercised against the examples in its own
 documentation, and a syntax matrix over the input spellings each tool must accept. Both
@@ -19,8 +19,14 @@ default response cache breaks state and isolation across clients. It also found
 correctness gaps in named-workspace cancellation, exact large integers, streaming,
 persistence, workspace routing and version synchronization. All are tracked with
 evidence, a suggested fix and a verification step in
-[REVIEW_ACTIONS.md](REVIEW_ACTIONS.md). Review items 1, 2 and 10 outrank everything
-below.
+[REVIEW_ACTIONS.md](REVIEW_ACTIONS.md).
+
+**Status: fifteen of seventeen closed.** The validator took three rounds — direct
+spellings, then aliases of forbidden functions (`f = open`), then aliases of
+forbidden modules (`m = os`) — because each fix was checked only against the
+payloads that motivated it. The two that remain are item 4 (splitting `server.py`,
+deferred until the open PR stack merges) and the account-side half of item 7
+(Smithery and Glama submissions, which need repository-owner access).
 
 ## Competitive position (surveyed 2026-08-13)
 
@@ -98,7 +104,7 @@ architectural change.
 - [x] **Named multi-sessions.** `start_sage_session`, `list_sage_sessions` and
       `stop_sage_session`, with workspace selection on raw evaluation and session
       controls. The default workspace keys on the bare scope.
-- [ ] **Correct named-session routing.** Cancellation must target the selected
+- [x] **Correct named-session routing.** Cancellation must target the selected
       workspace, response ids must be verified, and specialized tools must expose
       the same `session` selector (review items 11 and 16).
 
@@ -166,10 +172,10 @@ distribution and session ergonomics, not coverage.
 
 - [x] **Enriched `evaluate_sage` description** — 14 domain examples (was 8): added symbolic sums, Laplace/inverse Laplace transforms, modular arithmetic, vector calculus, numeric root finding, recurrence relations
 - [x] **HTTP `/health` endpoint** — returns `{"status": "ok", "version": "...", "active_sessions": N}` for Kubernetes liveness/readiness probes (Starlette route on HTTP transports)
-- [x] **`evaluate_sage_streaming` facade** — currently replays captured stdout as progress events after execution finishes.
-- [ ] **True incremental streaming** — extend the worker protocol so stdout events arrive while execution is running (review item 13).
+- [x] **`evaluate_sage_streaming`** — shipped first as a facade that replayed captured stdout after completion; now streams each line as it is produced (see the entry below).
+- [x] **True incremental streaming** — the worker emits a stdout event per completed line while execution is running, and the session dispatches them as they arrive (review item 13).
 - [x] **Disk-backed session persistence foundation** — code journals are saved on explicit stop/server shutdown and replayed on restore. Controlled by `SAGEMATH_MCP_PERSIST_SESSIONS` and `SAGEMATH_MCP_PERSIST_DIR`.
-- [ ] **Complete persistence lifecycle and isolation** — save journals during idle culling and replace lossy filename sanitization with collision-free identities (review items 14 and 15).
+- [x] **Complete persistence lifecycle and isolation** — journals are saved during idle culling, filenames carry a digest of the full session id in a versioned namespace, writes are atomic, and journals from the previous naming schemes are still restored (review items 14 and 15).
 
 ## Phase 4 — Niche Domains (Not Planned)
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,12 +22,12 @@
 
 ## Current priority queue
 
-- [ ] **Release blocker:** disable stateful tool/resource response caching and add two-client isolation tests ([review item 10](REVIEW_ACTIONS.md)).
-- [ ] **Release blocker:** close the AST-validator bypasses, correct the public sandbox claims, and harden the real container boundary ([review items 1-3](REVIEW_ACTIONS.md)).
-- [ ] Fix named-workspace cancellation and validate worker response ids ([review item 11](REVIEW_ACTIONS.md)).
-- [ ] Reject every numeric integer above `2^53`; require decimal strings for exact large values ([review item 12](REVIEW_ACTIONS.md)).
-- [ ] Implement actual incremental stdout events or rename the buffered streaming facade ([review item 13](REVIEW_ACTIONS.md)).
-- [ ] Persist idle-culled sessions and make journal filenames collision-free ([review items 14-15](REVIEW_ACTIONS.md)).
-- [ ] Add named-workspace selection to every specialized worker-backed tool ([review item 16](REVIEW_ACTIONS.md)).
-- [ ] Synchronize both `server.json` versions in `scripts/bump_version.py` and add a consistency test ([review item 17](REVIEW_ACTIONS.md)).
-- [ ] Work through the remaining maintainability, release-dry-run, dependency-audit and distribution actions in [REVIEW_ACTIONS.md](REVIEW_ACTIONS.md).
+- [x] **Release blocker:** disable stateful tool/resource response caching and add two-client isolation tests ([review item 10](REVIEW_ACTIONS.md)).
+- [x] **Release blocker:** close the AST-validator bypasses, correct the public sandbox claims, and harden the real container boundary ([review items 1-3](REVIEW_ACTIONS.md)). Took three rounds: direct spellings, then aliases of forbidden functions, then aliases of forbidden modules.
+- [x] Fix named-workspace cancellation and validate worker response ids ([review item 11](REVIEW_ACTIONS.md)). Includes `reset()`, which was still reading the next line unconditionally.
+- [x] Reject every numeric integer above `2^53`; require decimal strings for exact large values ([review item 12](REVIEW_ACTIONS.md)).
+- [x] Implement actual incremental stdout events or rename the buffered streaming facade ([review item 13](REVIEW_ACTIONS.md)) — implemented, not renamed.
+- [x] Persist idle-culled sessions and make journal filenames collision-free ([review items 14-15](REVIEW_ACTIONS.md)), with a fallback so the rename does not orphan journals written by earlier versions.
+- [x] Add named-workspace selection to every specialized worker-backed tool ([review item 16](REVIEW_ACTIONS.md)).
+- [x] Synchronize both `server.json` versions in `scripts/bump_version.py` and add a consistency test ([review item 17](REVIEW_ACTIONS.md)).
+- [ ] Remaining from the review: split `server.py` (item 4, deferred until the PR stack merges) and the account-side Smithery/Glama submissions (item 7).

--- a/USAGE.md
+++ b/USAGE.md
@@ -126,4 +126,4 @@ For HTTP transports, point the client at `http://HOST:PORT/mcp` and enable strea
 - **ModuleNotFoundError for `sage`**: ensure the server is launched via `sage -python ...` so Sage’s site-packages are on `PYTHONPATH`.
 - **Long-running jobs**: use `cancel_sage_session`; the server restarts the worker and logs a warning for the calling context.
 - **Idle sessions**: the background culler removes sessions after `SAGEMATH_MCP_IDLE_TTL` seconds (default 900). Adjust via environment variables as documented in `README.md`.
-- **Permission denied on volume mounts**: confirm the host path is writable by UID/GID 1001; adjust ownership with `chown -R 1001:1001 <path>` when using Docker Compose or Helm.
+- **Permission denied on volume mounts**: the checkout is mounted read-only on purpose, so a write failure there is usually the application trying to write where it should not. If the path really is meant to be writable (a persistence volume), give that single path to UID/GID 1001 — not the whole tree.

--- a/charts/sagemath-mcp/templates/deployment.yaml
+++ b/charts/sagemath-mcp/templates/deployment.yaml
@@ -88,17 +88,35 @@ spec:
           envFrom:
             {{- toYaml .Values.extraEnvFrom | nindent 12 }}
           {{- end }}
-          {{- if .Values.extraVolumeMounts }}
+          {{- if or .Values.extraVolumeMounts .Values.scratchVolumes.enabled }}
           volumeMounts:
-            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- if .Values.scratchVolumes.enabled }}
+            - name: tmp
+              mountPath: /tmp
+            - name: sage-home
+              mountPath: {{ .Values.scratchVolumes.sageHomePath }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if .Values.extraVolumes }}
+      {{- if or .Values.extraVolumes .Values.scratchVolumes.enabled }}
       volumes:
-        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- if .Values.scratchVolumes.enabled }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.scratchVolumes.tmpSizeLimit }}
+        - name: sage-home
+          emptyDir:
+            sizeLimit: {{ .Values.scratchVolumes.sageHomeSizeLimit }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/sagemath-mcp/values.yaml
+++ b/charts/sagemath-mcp/values.yaml
@@ -32,9 +32,21 @@ securityContext:
   runAsUser: 1001
   runAsGroup: 1001
   allowPrivilegeEscalation: false
+  # Sage needs a writable temp dir and its own dot-directory, and nothing else.
+  # The emptyDir mounts below supply both; without them the container fails with
+  # "No usable temporary directory found". Verified against the real image.
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
       - ALL
+
+# Writable scratch for a read-only root filesystem. Sized to match the tmpfs
+# mounts in docker-compose.yml so the two deployments behave the same.
+scratchVolumes:
+  enabled: true
+  tmpSizeLimit: 512Mi
+  sageHomeSizeLimit: 256Mi
+  sageHomePath: /home/sage/.sage
 
 service:
   type: ClusterIP
@@ -67,7 +79,16 @@ startupProbe:
   timeoutSeconds: 5
   failureThreshold: 12
 
-resources: {}
+# Defaults, not an empty map: an unbounded pod is one runaway computation away
+# from evicting its neighbours, and mem_limit/pids_limit are already set on the
+# compose side. Raise for heavy workloads; Sage itself wants ~1Gi at rest.
+resources:
+  requests:
+    cpu: 250m
+    memory: 1Gi
+  limits:
+    cpu: "2"
+    memory: 4Gi
 
 nodeSelector: {}
 tolerations: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,13 @@ services:
     # the boundary. A sandbox escape was demonstrated reading every environment
     # variable, reading the mounted checkout and opening outbound sockets, so
     # the blast radius is bounded here rather than in the validator alone.
-    read_only: false          # Sage writes to $HOME; the mount below is ro
+    # Verified working: Sage needs a writable temp dir and its own dot-directory
+    # and nothing else. Without the two tmpfs mounts below it fails outright
+    # ("No usable temporary directory found"), which is how they were sized.
+    read_only: true
+    tmpfs:
+      - /tmp:rw,size=512m
+      - /home/sage/.sage:rw,size=256m
     cap_drop:
       - ALL
     security_opt:

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,46 @@
+# Smithery listing configuration.
+#
+# Smithery reads this from the repository root to work out how to launch the
+# server. Publishing still requires connecting this repository at smithery.ai
+# with an account that owns it; this file is the half that lives in git.
+#
+# SageMath itself is a large dependency and is not bundled here: the command
+# below assumes `sage` is on PATH. Callers who do not have it should use the
+# published container image instead, which carries the runtime.
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      sageBinary:
+        type: string
+        default: sage
+        description: >-
+          Path to the SageMath executable. Leave as "sage" to use PATH.
+      evalTimeout:
+        type: number
+        default: 30
+        description: Seconds before a single evaluation is abandoned.
+      idleTtl:
+        type: number
+        default: 900
+        description: Seconds an idle session is kept before its worker is reclaimed.
+      securityEnabled:
+        type: boolean
+        default: true
+        description: >-
+          Keep the AST policy on. It is defence in depth against accidents, not
+          a boundary against adversarial code -- run the container for that.
+    required: []
+  commandFunction: |-
+    (config) => ({
+      command: 'sagemath-mcp',
+      args: [],
+      env: {
+        SAGEMATH_MCP_SAGE_BINARY: config.sageBinary || 'sage',
+        SAGEMATH_MCP_EVAL_TIMEOUT: String(config.evalTimeout ?? 30),
+        SAGEMATH_MCP_IDLE_TTL: String(config.idleTtl ?? 900),
+        SAGEMATH_MCP_SECURITY_ENABLED: String(config.securityEnabled ?? true)
+      }
+    })

--- a/src/sagemath_mcp/_sage_worker.py
+++ b/src/sagemath_mcp/_sage_worker.py
@@ -32,6 +32,9 @@ def _build_namespace() -> dict[str, Any]:
     preload = "from math import *" if PURE_PYTHON else STARTUP_CODE
     if preload:
         try:
+            # The preload needs real builtins: importing sage.all uses
+            # __import__, open and more. Restrict only afterwards, so user code
+            # never sees them.
             exec(preload, ns)
             _STARTUP_ERROR = None
         except Exception as exc:
@@ -40,7 +43,42 @@ def _build_namespace() -> dict[str, Any]:
                 json.dumps({"ok": False, "startup_error": _STARTUP_ERROR}),
                 file=sys.stderr,
             )
+    ns["__builtins__"] = _restricted_builtins()
     return ns
+
+
+# Builtins that are dangerous in this context and have no place in a maths
+# expression. The AST policy blocks these names too; removing them from the
+# namespace is the backstop for when it misses a spelling -- as it did for
+# `f = open`, which the validator only caught in call position.
+_DENIED_BUILTINS = frozenset(
+    {
+        "open",
+        "eval",
+        "exec",
+        "compile",
+        "input",
+        "breakpoint",
+        "globals",
+        "locals",
+        "vars",
+        "memoryview",
+        "help",
+        "exit",
+        "quit",
+    }
+)
+
+
+def _restricted_builtins() -> dict[str, Any]:
+    """Builtins for user code: everything except the dangerous handful.
+
+    __import__ deliberately stays. Sage imports lazily on first use, so removing
+    it breaks ordinary mathematics well after startup. The name is unreachable
+    from caller code anyway: the policy blocks dunder references outright.
+    """
+    source = __builtins__ if isinstance(__builtins__, dict) else vars(__builtins__)
+    return {name: value for name, value in source.items() if name not in _DENIED_BUILTINS}
 
 
 def _latex(result: Any) -> str | None:

--- a/src/sagemath_mcp/_sage_worker.py
+++ b/src/sagemath_mcp/_sage_worker.py
@@ -44,7 +44,19 @@ def _build_namespace() -> dict[str, Any]:
                 file=sys.stderr,
             )
     ns["__builtins__"] = _restricted_builtins()
+    _strip_forbidden_modules(ns)
     return ns
+
+
+def _strip_forbidden_modules(ns: dict[str, Any]) -> None:
+    """Drop module objects the policy forbids from the user namespace.
+
+    `from sage.all import *` binds os, sys and friends as ordinary globals, so
+    `m = os` handed caller code the real module. The validator now refuses to
+    read those names, and this makes the object unreachable even if it does.
+    """
+    for name in SECURITY_POLICY.forbidden_attribute_parents:
+        ns.pop(name, None)
 
 
 # Builtins that are dangerous in this context and have no place in a maths

--- a/src/sagemath_mcp/security.py
+++ b/src/sagemath_mcp/security.py
@@ -286,6 +286,23 @@ def validate_module(
                     code=code,
                     policy=policy,
                 )
+            # An allowed module can re-export a forbidden one. `sage` is on the
+            # allowlist and `from sage.all import os as m` bound the real os
+            # module under a fresh name, which then passed every later rule
+            # because the name being read was `m`. Judge what is imported, not
+            # only where it comes from.
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                if (
+                    root in policy.forbidden_attribute_parents
+                    or root in policy.forbidden_call_names
+                ):
+                    _raise_violation(
+                        f"Importing '{alias.name}' is blocked "
+                        f"('{root}' is not permitted in Sage executions)",
+                        code=code,
+                        policy=policy,
+                    )
         if isinstance(node, ast.Global) and policy.forbid_global_stmt:
             _raise_violation(
                 "Global statements are not permitted in Sage executions",
@@ -341,16 +358,27 @@ def validate_module(
         # through calculate_expression. Any expression that stores, defaults,
         # or packs the name into a container works the same way, so the check
         # belongs on the Name node itself.
-        if (
-            isinstance(node, ast.Name)
-            and isinstance(node.ctx, ast.Load)
-            and node.id in policy.forbidden_call_names
-        ):
-            _raise_violation(
-                f"Reference to forbidden name '{node.id}' is blocked",
-                code=code,
-                policy=policy,
-            )
+        # The same reasoning applies to the forbidden MODULES, and the first fix
+        # missed them: the attribute rule above inspects an ast.Attribute chain,
+        # so it saw os.getuid() but not
+        #     m = os;                      m.getuid()
+        #     from sage.all import os as m;m.getuid()
+        # Both returned the container uid from real SageMath. Once the module
+        # object is bound to an unremarkable name there is no chain left to
+        # inspect, so the module name has to be unreadable in the first place.
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            if node.id in policy.forbidden_call_names:
+                _raise_violation(
+                    f"Reference to forbidden name '{node.id}' is blocked",
+                    code=code,
+                    policy=policy,
+                )
+            if node.id in policy.forbidden_attribute_parents:
+                _raise_violation(
+                    f"Reference to forbidden module '{node.id}' is blocked",
+                    code=code,
+                    policy=policy,
+                )
         if isinstance(node, ast.Call):
             func = node.func
             if isinstance(func, ast.Name) and func.id in policy.forbidden_call_names:

--- a/src/sagemath_mcp/security.py
+++ b/src/sagemath_mcp/security.py
@@ -332,6 +332,25 @@ def validate_module(
                     )
                     break
 
+        # A forbidden builtin is forbidden wherever it is REFERENCED, not only
+        # where it is called. Checking ast.Call.func alone let the name be
+        # aliased first and called through the alias:
+        #     f = open;                    f('/etc/passwd').readline()
+        #     (lambda f=open: f('/etc/passwd').readline())()
+        # Both returned the first line of /etc/passwd, through evaluate_sage and
+        # through calculate_expression. Any expression that stores, defaults,
+        # or packs the name into a container works the same way, so the check
+        # belongs on the Name node itself.
+        if (
+            isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Load)
+            and node.id in policy.forbidden_call_names
+        ):
+            _raise_violation(
+                f"Reference to forbidden name '{node.id}' is blocked",
+                code=code,
+                policy=policy,
+            )
         if isinstance(node, ast.Call):
             func = node.func
             if isinstance(func, ast.Name) and func.id in policy.forbidden_call_names:

--- a/src/sagemath_mcp/server.py
+++ b/src/sagemath_mcp/server.py
@@ -6,10 +6,12 @@ import argparse
 import ast
 import asyncio
 import contextlib
+import io
 import json
 import logging
 import re
 import textwrap
+import tokenize
 from collections.abc import AsyncIterator, Iterable
 from typing import Annotated
 
@@ -483,6 +485,39 @@ def _normalize_source(value):
     return value
 
 
+# A single "=" that is not part of ==, <=, >= or !=. Sage accepts it as an
+# equation; Python does not accept it as an expression at all.
+_EQUALS_NOT_COMPARISON = re.compile(r"(?<![=<>!])=(?!=)")
+
+
+def _screen_unparseable_fragment(fragment: str) -> None:
+    """Reject forbidden names in a fragment that would not parse.
+
+    Full AST validation needs a parse tree. When there is none, screen the token
+    stream instead: a name is a name whatever surrounds it, and this is the last
+    gate before the fragment is interpolated into trusted, sage_eval'd code.
+    """
+    forbidden = set(SECURITY_POLICY.forbidden_call_names) | set(
+        SECURITY_POLICY.forbidden_attribute_parents
+    )
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(fragment).readline))
+    except (tokenize.TokenError, IndentationError) as exc:
+        raise ToolError(
+            f"Could not read {fragment!r} as an expression: {exc}"
+        ) from exc
+    for token in tokens:
+        if token.type != tokenize.NAME:
+            continue
+        if token.string in forbidden or (
+            token.string.startswith("__") and token.string.endswith("__")
+        ):
+            raise ToolError(
+                f"Rejected by the security policy: reference to "
+                f"'{token.string}' is blocked"
+            )
+
+
 def _validated_expression(text: str) -> str:
     """Check a caller-supplied fragment before it is embedded in generated code.
 
@@ -502,10 +537,22 @@ def _validated_expression(text: str) -> str:
     try:
         parsed = ast.parse(stripped, mode="eval")
     except SyntaxError:
-        # Not parseable as a Python expression. Sage's preparser accepts things
-        # Python does not (R.<a,b> = ...), so this is not automatically a
-        # violation; let the worker report the real error.
-        return text
+        # Returning the fragment unvalidated here made "unparseable" a way to
+        # skip validation entirely, since it is then interpolated into sage_eval
+        # under the trusted policy. But rejecting outright is wrong too: the
+        # documented equation form "x^2 - 1 = 0" is deliberately not a Python
+        # expression. So try the Sage spelling first, and screen whatever is
+        # left at token level rather than waving it through.
+        equation = _EQUALS_NOT_COMPARISON.sub("==", stripped)
+        if equation != stripped:
+            try:
+                parsed = ast.parse(equation, mode="eval")
+            except SyntaxError:
+                _screen_unparseable_fragment(stripped)
+                return text
+        else:
+            _screen_unparseable_fragment(stripped)
+            return text
     try:
         validate_module(
             ast.Module(body=[ast.Expr(value=parsed.body)], type_ignores=[]),

--- a/src/sagemath_mcp/server.py
+++ b/src/sagemath_mcp/server.py
@@ -71,8 +71,12 @@ Guidance for best results:
 - Long-running jobs emit progress heartbeat events roughly every 1.5 seconds. You can adjust
   timeouts via the `timeout` parameter.
 - Capture stdout only when needed; disabling it speeds up large iterations.
-- The security sandbox blocks arbitrary imports, `eval`, and filesystem/process APIs. If you
-  hit a security violation, rewrite the computation with Sage primitives instead.
+- The security policy rejects arbitrary imports, `eval`/`exec`, the indirection helpers
+  (`getattr`, `sage_eval`), dunder access, and the `os`/`sys`/`subprocess`/`shutil`/
+  `socket`/`pathlib` modules -- wherever those names are read, not only where they are
+  called. It is defence in depth against accidents, not a boundary against adversarial
+  code; the container is the boundary. If you hit a security violation, rewrite the
+  computation with Sage primitives instead.
 """.strip()
 
 SETTINGS = DEFAULT_SETTINGS

--- a/src/sagemath_mcp/session.py
+++ b/src/sagemath_mcp/session.py
@@ -21,6 +21,12 @@ from pathlib import Path
 from .config import DEFAULT_SETTINGS, SageSettings
 
 LOGGER = logging.getLogger(__name__)
+
+# Subdirectory holding journals written by the current naming scheme.
+_JOURNAL_NAMESPACE = "v2"
+
+# How many non-matching lines to skip before declaring the worker unusable.
+_MAX_DISCARDED_RESPONSES = 64
 _PROJECT_ROOT = str(Path(__file__).resolve().parents[1])
 
 # Workspace used when a caller does not name one.
@@ -146,6 +152,7 @@ class SageSession:
         replay after completion.
         """
         assert self._process and self._process.stdout
+        discarded = 0
         while True:
             raw = await self._process.stdout.readline()
             if not raw:
@@ -160,9 +167,21 @@ class SageSession:
                     await on_stdout(message.get("text", ""))
                 continue
             incoming = message.get("id")
-            if incoming is not None and incoming != request_id:
+            if incoming != request_id:
+                # Including id-less lines. Accepting those let anything the
+                # worker printed stand in for the answer to this request.
+                discarded += 1
+                if discarded > _MAX_DISCARDED_RESPONSES:
+                    # Bounded, because "keep reading until the right id turns
+                    # up" is unbounded when the peer keeps repeating itself: a
+                    # worker stuck on one line spun here until the process ran
+                    # out of memory.
+                    raise SageProcessError(
+                        f"Sage worker sent {discarded} responses that do not answer "
+                        f"request {request_id}; abandoning it."
+                    )
                 LOGGER.warning(
-                    "Discarding stale worker response %s in %s (waiting for %s)",
+                    "Discarding stale worker response %r in %s (waiting for %s)",
                     incoming, self.session_id, request_id,
                 )
                 continue
@@ -205,6 +224,16 @@ class SageSession:
                 raise TimeoutError(
                     f"Sage evaluation timed out after {effective_timeout:.2f}s"
                 ) from exc
+            except asyncio.CancelledError:
+                # The caller went away, but the worker is still computing: the
+                # next request would queue behind a computation nobody wants.
+                # Only evaluate_sage used to handle this, by restarting the
+                # worker; streaming and the specialised tools left it running.
+                # Interrupting here covers all three and keeps the namespace,
+                # and the resulting "Interrupted" response is discarded by the
+                # id check in _read_response.
+                await self.interrupt()
+                raise
             if not raw:
                 raise SageProcessError("Sage worker terminated unexpectedly.")
         self.last_used_at = time.time()
@@ -229,7 +258,11 @@ class SageSession:
         """Return the journal file path if persistence is enabled."""
         if not self.settings.persist_sessions or not self.settings.persist_dir:
             return None
-        d = Path(self.settings.persist_dir)
+        # Versioned namespace: digest-named files live in their own directory
+        # so they cannot collide with a legacy flat file that happens to share a
+        # name, and so a future scheme change is a new directory rather than
+        # another round of ambiguity.
+        d = Path(self.settings.persist_dir) / _JOURNAL_NAMESPACE
         d.mkdir(parents=True, exist_ok=True)
         return d / f"{self._journal_stem()}.journal.json"
 
@@ -245,12 +278,17 @@ class SageSession:
         if not self.settings.persist_sessions or not self.settings.persist_dir:
             return []
         d = Path(self.settings.persist_dir)
-        candidates = [
-            d / f"{self.session_id}.journal.json",
-            d / f"{re.sub(r'[^A-Za-z0-9._-]', '_', self.session_id)}.journal.json",
-        ]
-        # Deduplicate while preserving order; for default sessions the two are
-        # the same path.
+        # The un-namespaced digest file, from the scheme between the two. The
+        # digest covers the whole session id, so this one names its owner
+        # unambiguously and is always safe to adopt.
+        candidates = [d / f"{self._journal_stem()}.journal.json"]
+        # The oldest scheme sanitised unsafe characters away, which is exactly
+        # why it was replaced: "a/b" and "a?b" both wrote "a_b.journal.json".
+        # Adopting such a file would be guessing whose state it is, so fall back
+        # only when the sanitisation changed nothing and the name proves identity.
+        sanitized = re.sub(r"[^A-Za-z0-9._-]", "_", self.session_id)
+        if sanitized == self.session_id and self.session_id:
+            candidates.append(d / f"{self.session_id}.journal.json")
         seen: set[Path] = set()
         return [p for p in candidates if not (p in seen or seen.add(p))]
 
@@ -292,7 +330,11 @@ class SageSession:
                         legacy.unlink()
         if path is None:
             return
-        path.write_text(json.dumps(self._code_journal))
+        # Atomic: a crash or a full disk mid-write previously left a truncated
+        # journal that failed to parse on the next start, losing the session.
+        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(self._code_journal))
+        os.replace(tmp, path)
         LOGGER.debug("Saved journal for %s (%d entries)", self.session_id, len(self._code_journal))
 
     @classmethod
@@ -328,10 +370,13 @@ class SageSession:
         async with self._lock:
             self._process.stdin.write(data)
             await self._process.stdin.drain()
-            raw = await self._process.stdout.readline()
+            # Match the response id, exactly as evaluate() does. Reading the next
+            # line unconditionally meant a cancelled evaluation's response was
+            # consumed here: reset saw someone else's failure and reported
+            # "Failed to reset Sage session" for a reset that was fine.
+            raw, response = await self._read_response(payload["id"])
             if not raw:
                 raise SageProcessError("Sage worker terminated during reset.")
-        response = json.loads(raw.decode("utf-8"))
         if not response.get("ok", False):
             raise SageProcessError("Failed to reset Sage session.")
         self._code_journal.clear()

--- a/src/sagemath_mcp/session.py
+++ b/src/sagemath_mcp/session.py
@@ -233,6 +233,40 @@ class SageSession:
         d.mkdir(parents=True, exist_ok=True)
         return d / f"{self._journal_stem()}.journal.json"
 
+    def _legacy_persist_paths(self) -> list[Path]:
+        """Journal paths written by earlier versions of this code.
+
+        Two schemes preceded the digest: the raw session id, and a lossy
+        sanitisation of it. Both are still on disk for anyone upgrading, and
+        without this the rename silently orphans every persisted session --
+        including plain default ones, whose filename was previously just the
+        session id.
+        """
+        if not self.settings.persist_sessions or not self.settings.persist_dir:
+            return []
+        d = Path(self.settings.persist_dir)
+        candidates = [
+            d / f"{self.session_id}.journal.json",
+            d / f"{re.sub(r'[^A-Za-z0-9._-]', '_', self.session_id)}.journal.json",
+        ]
+        # Deduplicate while preserving order; for default sessions the two are
+        # the same path.
+        seen: set[Path] = set()
+        return [p for p in candidates if not (p in seen or seen.add(p))]
+
+    def existing_journal_path(self) -> Path | None:
+        """The journal to restore from, preferring the current scheme."""
+        current = self._persist_path()
+        if current is not None and current.exists():
+            return current
+        for legacy in self._legacy_persist_paths():
+            if legacy.exists():
+                LOGGER.info(
+                    "Restoring %s from a legacy journal path (%s)", self.session_id, legacy.name
+                )
+                return legacy
+        return None
+
     def _journal_stem(self) -> str:
         """A filename that is unique per session id.
 
@@ -250,6 +284,12 @@ class SageSession:
     def save_journal(self) -> None:
         """Write the code journal to disk for later restoration."""
         path = self._persist_path()
+        if path is not None:
+            # Retire any pre-digest file so the two schemes cannot diverge.
+            for legacy in self._legacy_persist_paths():
+                if legacy != path and legacy.exists():
+                    with contextlib.suppress(OSError):
+                        legacy.unlink()
         if path is None:
             return
         path.write_text(json.dumps(self._code_journal))
@@ -443,8 +483,9 @@ class SageSessionManager:
         await session.ensure_started()
         # Restore persisted journal if available
         if not session._code_journal:
-            path = session._persist_path()
-            if path and path.exists():
+            # Falls back to pre-digest filenames so upgrading does not lose state.
+            path = session.existing_journal_path()
+            if path:
                 journal = SageSession.load_journal(path)
                 if journal:
                     LOGGER.info(

--- a/tests/test_generated_code_lint.py
+++ b/tests/test_generated_code_lint.py
@@ -213,6 +213,16 @@ def test_readme_security_table_matches_the_policy() -> None:
     for builtin in README_BLOCKED_BUILTINS:
         if not rejects(f"{builtin}('x')"):
             unenforced.append(f"{builtin}() is documented as blocked but is allowed")
+        # Call position is not enough. This test used to check only the spelling
+        # above, which is why `f = open` survived it: the README said "blocked"
+        # and the test agreed, while an alias walked straight through.
+        for spelling, label in (
+            (f"f = {builtin}", "alias assignment"),
+            (f"(lambda f={builtin}: f)()", "lambda default"),
+            (f"[{builtin}][0]", "container literal"),
+        ):
+            if not rejects(spelling):
+                unenforced.append(f"{builtin} is reachable by {label}: {spelling!r}")
     for payload in ("().__class__", "obj.__globals__", "__builtins__.__import__"):
         if not rejects(payload):
             unenforced.append(f"dunder access {payload!r} is documented as blocked but is allowed")

--- a/tests/test_security_bypass.py
+++ b/tests/test_security_bypass.py
@@ -80,3 +80,47 @@ ALLOWED = [
 @pytest.mark.parametrize(("case_id", "payload"), ALLOWED, ids=[c for c, _ in ALLOWED])
 def test_legitimate_code_still_passes(case_id: str, payload: str) -> None:
     _validate(payload)
+
+
+# Every spelling below reaches a forbidden builtin WITHOUT naming it in call
+# position. The first two were reported as still exploitable after the initial
+# hardening: both returned the first line of /etc/passwd, through evaluate_sage
+# and through calculate_expression. Checking ast.Call.func alone is not enough --
+# the name has to be rejected wherever it is referenced.
+ALIASING_PAYLOADS = [
+    ("alias-assignment", "f = open\nf('/etc/passwd').readline()"),
+    ("lambda-default", "(lambda f=open: f('/etc/passwd').readline())()"),
+    ("alias-getattr", "g = getattr\ng(os, 'getuid')()"),
+    ("list-literal", "[open][0]('/etc/passwd').readline()"),
+    ("tuple-literal", "(open,)[0]('/etc/passwd').read()"),
+    ("dict-value", "{'k': open}['k']('/etc/passwd').read()"),
+    ("comprehension", "[fn for fn in (open,)][0]('/etc/passwd').read()"),
+    ("bare-reference", "open"),
+    ("default-in-def", "def g(h=eval):\n    return h('1+1')\ng()"),
+    ("conditional-alias", "f = open if True else print\nf('/etc/passwd')"),
+    ("alias-sage-eval", "se = sage_eval\nse(\"__import__('os').getuid()\")"),
+]
+
+
+@pytest.mark.parametrize(
+    ("case_id", "payload"), ALIASING_PAYLOADS, ids=[c for c, _ in ALIASING_PAYLOADS]
+)
+def test_forbidden_names_cannot_be_aliased(case_id: str, payload: str) -> None:
+    with pytest.raises(SecurityViolation):
+        _validate(payload)
+
+
+def test_restricted_builtins_exclude_the_dangerous_ones() -> None:
+    """The namespace backstop, independent of the AST rules.
+
+    If a spelling ever slips past the validator again, the object should not be
+    reachable in the first place.
+    """
+    from sagemath_mcp._sage_worker import _restricted_builtins
+
+    available = _restricted_builtins()
+    for denied in ("open", "eval", "exec", "compile", "input", "globals", "locals", "vars"):
+        assert denied not in available, f"{denied} is still reachable in the worker namespace"
+    # Ordinary mathematics must keep working.
+    for needed in ("abs", "len", "range", "sum", "int", "float", "print", "sorted", "__import__"):
+        assert needed in available, f"{needed} was removed and normal code will break"

--- a/tests/test_security_bypass.py
+++ b/tests/test_security_bypass.py
@@ -124,3 +124,77 @@ def test_restricted_builtins_exclude_the_dangerous_ones() -> None:
     # Ordinary mathematics must keep working.
     for needed in ("abs", "len", "range", "sum", "int", "float", "print", "sorted", "__import__"):
         assert needed in available, f"{needed} was removed and normal code will break"
+
+
+# Aliasing a forbidden MODULE, which the first alias fix did not cover: it
+# checked forbidden call names only, so `m = os` still handed over the module.
+MODULE_ALIAS_PAYLOADS = [
+    ("bare module load", "os"),
+    ("module alias", "m = os\nm.getuid()"),
+    ("module alias via tuple", "(a, b) = (os, sys)\na.getuid()"),
+    ("module in a container", "[os][0].getuid()"),
+    ("module as a default", "(lambda m=os: m.getuid())()"),
+    ("import-as alias", "from sage.all import os as m\nm.getuid()"),
+    ("import-as under another name", "from sage.all import subprocess as sp"),
+    ("sys alias", "s = sys\ns.modules"),
+    ("shutil alias", "sh = shutil\nsh.rmtree('/tmp/x')"),
+    ("socket alias", "sk = socket\nsk.socket()"),
+    ("pathlib alias", "pl = pathlib\npl.Path('/etc/passwd').read_text()"),
+    ("builtins alias", "b = builtins\nb.open('/etc/passwd')"),
+]
+
+
+@pytest.mark.parametrize(
+    "label,payload", MODULE_ALIAS_PAYLOADS, ids=[p[0] for p in MODULE_ALIAS_PAYLOADS]
+)
+def test_module_aliases_are_blocked(label: str, payload: str) -> None:
+    """`m = os` returned the container uid from real SageMath before this."""
+    with pytest.raises(SecurityViolation):
+        validate_module(ast.parse(payload), code=payload, policy=SECURITY_POLICY)
+
+
+def test_forbidden_modules_are_absent_from_the_worker_namespace() -> None:
+    """Second layer: even if a spelling slips past, there is nothing to bind.
+
+    `from sage.all import *` binds os, sys and friends as ordinary globals.
+    """
+    from sagemath_mcp._sage_worker import _build_namespace
+
+    namespace = _build_namespace()
+    present = [
+        name for name in SECURITY_POLICY.forbidden_attribute_parents if name in namespace
+    ]
+    assert not present, f"forbidden modules reachable in the worker namespace: {present}"
+
+
+def test_specialized_tool_rejects_an_aliased_payload() -> None:
+    """The public path, not just the validator.
+
+    calculate_expression embeds its argument into generated code that runs under
+    the trusted policy, so a fragment that escapes _validated_expression is not
+    validated again downstream.
+    """
+    from fastmcp.exceptions import ToolError
+
+    from sagemath_mcp.server import _validated_expression
+
+    for payload in (
+        "(lambda f=open: f('/etc/passwd').readline())()",
+        "[os][0].getuid()",
+        "(lambda m=os: m.getuid())()",
+    ):
+        with pytest.raises(ToolError, match="security policy"):
+            _validated_expression(payload)
+
+
+def test_unparseable_fragments_are_screened_not_waved_through() -> None:
+    """A fragment that will not parse used to skip validation entirely."""
+    from fastmcp.exceptions import ToolError
+
+    from sagemath_mcp.server import _validated_expression
+
+    # Still accepted: the documented equation spelling is not a Python expression.
+    assert _validated_expression("x^2 - 1 = 0") == "x^2 - 1 = 0"
+    # Screened at token level once no parse tree is available.
+    with pytest.raises(ToolError):
+        _validated_expression("R.<a> = os.getuid()")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2152,3 +2152,37 @@ async def test_number_theory_accepts_big_integers_as_strings(monkeypatch):
     # The generated code must carry the exact value, not a float repr.
     assert "1000000000000000000000000000000" in session.calls[0]["code"]
     assert "e+30" not in session.calls[0]["code"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_streaming_then_reset_then_evaluate_on_a_named_workspace(
+    monkeypatch,
+):
+    """The whole sequence through the public tools, on one named workspace.
+
+    Streaming and the specialised tools did not clean up after a cancellation
+    the way evaluate_sage did, so an abandoned computation stayed running and
+    its response sat in the pipe for whoever read next.
+    """
+    settings = SageSettings(force_python_worker=True, eval_timeout=30.0)
+    manager = SageSessionManager(settings)
+    monkeypatch.setattr(server, "SESSION_MANAGER", manager)
+    ctx = FakeContext("cancel-stream-client")
+    try:
+        await server.evaluate_sage("anchor = 5", session="bench", ctx=ctx)
+
+        task = asyncio.create_task(
+            server.evaluate_sage_streaming(
+                "sum(range(60000000))\nnonexistent_name", session="bench", ctx=ctx
+            )
+        )
+        await asyncio.sleep(0.2)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        await server.reset_sage_session(session="bench", ctx=ctx)
+        result = await server.evaluate_sage("3 * 14", session="bench", ctx=ctx)
+        assert result.result == "42", "the workspace was unusable after cancel + reset"
+    finally:
+        await manager.shutdown()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import sys
 
 import pytest
@@ -876,5 +877,50 @@ async def test_idle_culling_persists_the_journal(tmp_path):
         restored = await manager.get("cull-persist")
         result = await restored.evaluate("survivor", want_latex=False, capture_stdout=False)
         assert result.result == "4321", "culling discarded the journal"
+    finally:
+        await manager.shutdown()
+
+
+def test_legacy_journal_is_still_found_after_the_rename(tmp_path):
+    """Upgrading must not orphan journals written by earlier versions.
+
+    The digest was added so distinct workspaces cannot collide, but it changed
+    every filename -- including plain default sessions, whose journal used to be
+    named after the session id alone.
+    """
+    settings = SageSettings(
+        force_python_worker=True, persist_sessions=True, persist_dir=str(tmp_path)
+    )
+    session = SageSession("legacy-client", settings)
+
+    # A journal written by the previous scheme.
+    legacy = tmp_path / "legacy-client.journal.json"
+    legacy.write_text(json.dumps(["heirloom = 11"]), encoding="utf-8")
+
+    found = session.existing_journal_path()
+    assert found == legacy, "the pre-digest journal was not found"
+    assert SageSession.load_journal(found) == ["heirloom = 11"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_journal_is_restored_and_migrated(tmp_path):
+    settings = SageSettings(
+        force_python_worker=True, persist_sessions=True, persist_dir=str(tmp_path)
+    )
+    (tmp_path / "migrate-me.journal.json").write_text(
+        json.dumps(["heirloom = 11"]), encoding="utf-8"
+    )
+
+    manager = SageSessionManager(settings)
+    try:
+        session = await manager.get("migrate-me")
+        result = await session.evaluate("heirloom", want_latex=False, capture_stdout=False)
+        assert result.result == "11", "legacy state was not restored"
+
+        session.save_journal()
+        assert session._persist_path().exists(), "journal was not written under the new name"
+        assert not (tmp_path / "migrate-me.journal.json").exists(), (
+            "the legacy file should be retired so the two schemes cannot diverge"
+        )
     finally:
         await manager.shutdown()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import json
 import sys
 
@@ -138,16 +139,42 @@ class _FakeWriter:
     def close(self) -> None:
         self.closed = True
 
+    def last_request_id(self) -> str | None:
+        """The id of the most recent request written, if any."""
+        lines = [line for line in bytes(self.data).splitlines() if line.strip()]
+        for line in reversed(lines):
+            try:
+                return json.loads(line.decode("utf-8")).get("id")
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+        return None
+
     async def wait_closed(self) -> None:
         return None
 
 
 class _FakeReader:
-    def __init__(self, data: bytes = b""):
+    """A stand-in worker stdout.
+
+    *echo_id_from* lets the canned response carry the id of the request that was
+    just written, which is what the real worker does. Without it the reader
+    answers with a line that belongs to no request, and the session correctly
+    refuses to accept it.
+    """
+
+    def __init__(self, data: bytes = b"", echo_id_from: "_FakeWriter | None" = None):
         self._data = data
+        self._echo_id_from = echo_id_from
 
     async def readline(self) -> bytes:
-        return self._data
+        if self._echo_id_from is None:
+            return self._data
+        request_id = self._echo_id_from.last_request_id()
+        if request_id is None:
+            return self._data
+        message = json.loads(self._data.decode("utf-8"))
+        message["id"] = request_id
+        return json.dumps(message).encode("utf-8") + b"\n"
 
 
 class _FakeProcess:
@@ -436,7 +463,9 @@ async def test_reset_worker_returns_failure(monkeypatch, python_settings):
 
     session = SageSession("reset-fail", python_settings)
     fake_process = _FakeProcess()
-    fake_process.stdout = _FakeReader(json.dumps({"ok": False}).encode() + b"\n")
+    fake_process.stdout = _FakeReader(
+        json.dumps({"ok": False}).encode() + b"\n", echo_id_from=fake_process.stdin
+    )
 
     async def fake_ensure_started():
         session._process = fake_process
@@ -924,3 +953,64 @@ async def test_legacy_journal_is_restored_and_migrated(tmp_path):
         )
     finally:
         await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_reset_after_a_cancelled_evaluation_does_not_read_the_stale_response(tmp_path):
+    """reset() must match response IDs like evaluate() does.
+
+    A cancelled evaluation leaves its response in the pipe. reset() read the
+    next line unconditionally, so it consumed that stale line, saw a response
+    for a different request and failed -- and the evaluation after it then had
+    to drain the reset's own response.
+    """
+    settings = SageSettings(force_python_worker=True, eval_timeout=30.0)
+    session = SageSession("stale-reset", settings)
+    await session.ensure_started()
+    try:
+        await session.evaluate("marker = 1", want_latex=False, capture_stdout=False)
+
+        # Cancel mid-flight; the worker still answers, into an empty pipe.
+        task = asyncio.create_task(
+            session.evaluate(
+                "sum(range(60000000))\nnonexistent_name",
+                want_latex=False,
+                capture_stdout=False,
+            )
+        )
+        await asyncio.sleep(0.2)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        await session.reset()          # used to raise SageProcessError
+        result = await session.evaluate("2 + 2", want_latex=False, capture_stdout=False)
+        assert result.result == "4", "the evaluation after reset read a stale response"
+    finally:
+        await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_worker_responses_without_the_expected_id_are_not_accepted(tmp_path):
+    """An ID-less line must not be taken as a request's final response."""
+    settings = SageSettings(force_python_worker=True, eval_timeout=30.0)
+    session = SageSession("id-required", settings)
+    await session.ensure_started()
+    try:
+        reader = session._process.stdout
+        original = reader.readline
+        lines = [
+            json.dumps({"ok": True, "result_type": "expression", "result": "'spoofed'"}).encode()
+            + b"\n"
+        ]
+
+        async def fake_readline():
+            if lines:
+                return lines.pop(0)
+            return await original()
+
+        reader.readline = fake_readline
+        result = await session.evaluate("6 * 7", want_latex=False, capture_stdout=False)
+        assert result.result == "42", "an ID-less response was accepted as the answer"
+    finally:
+        await session.shutdown()


### PR DESCRIPTION
Review item **7**, the half that can live in git. Stacked on #36.

`smithery.yaml` declares the stdio launch command and the four settings worth exposing: Sage binary path, evaluation timeout, idle TTL, and whether the AST policy stays on. It names the `sagemath-mcp` entry point that `pyproject.toml` actually defines — worth checking rather than assuming.

## The remaining half needs an account

Written into `REVIEW_ACTIONS.md` with URLs rather than left as "submit to both":

- **Smithery** — connect the repo at <https://smithery.ai/new> with an account that owns `XBP-Europe/sagemath-mcp`. It reads `smithery.yaml` from the default branch.
- **Glama** — indexes public MCP servers from GitHub automatically and ranks on metadata quality; the topics, description and README added earlier are what it reads. Claim the listing to edit it.

## One thing the listing should say out loud

SageMath is a large runtime and is **not bundled**. The command assumes `sage` is on PATH, so the container image is the better route for callers who don't have it — better stated on the listing than discovered by a user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaXrAUS1JhX6sMRfUZAsuA