### PR TITLE
Record final verification for review items 49-57

### DIFF
--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -2917,9 +2917,17 @@ is nearly free.
 All nine fixed, written test-first, and verified against real SageMath 10.9 in
 the `sage-mcp` container: the twelve escape payloads that ran a shell (or would
 have) now return `ok=False` with no marker file written, and the mathematics
-they collided with still computes. Unit suite 830 passed, coverage back to 100%
-(statements and branches), the denylist drift test and every math-coverage
-counterweight green.
+they collided with still computes.
+
+Shipped in PR #40 (squash-merged to `main` as `69221b4`). Full verification:
+host suite 830 passed; the complete container suite 972 passed (1 skipped, the
+opt-in doctest-execution run, which passes when enabled); coverage 100%
+(statements and branches); the denylist drift test and every math-coverage
+counterweight green; and all seven CI checks -- lint, security, test 3.12/3.13,
+smoke, helm, integration -- passed on the PR. Regenerating the allowlist removed
+exactly five names (`Pari`, `PariRing`, `PariGroup`, `libgap`, `Dokchitser`) and
+kept `PariError`, and `tests/test_sage_doctest_corpus.py` no longer asserts
+`libgap(5).Factorial()` works -- `factorial(5)` and the group methods cover it.
 
 **49 + 52 -- one rule, `security.py`.** The attribute-chain check now inspects
 every segment, not `segments[:-1]`. A forbidden name in **terminal** position is


### PR DESCRIPTION
Documentation-only follow-up to #40. Refreshes the `## Items 49-57, resolved` summary in `REVIEW_ACTIONS.md` to the final merged-and-verified state:

- Shipped in #40, squash-merged to `main` as `69221b4`.
- Host suite 830 passed; full container suite 972 passed (+1 opt-in doctest-execution pass); coverage 100%; all seven CI checks green.
- Notes the allowlist delta (five names removed, `PariError` kept) and the `test_sage_doctest_corpus.py` `libgap` assertion change.

No code or test changes — the per-item findings and fix write-ups are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
