### PR TITLE
Refuse terminal module names under any root (item 62)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,7 +211,10 @@ __marimo__/
 # Integration artifacts
 integration.log
 integration-artifacts.tar.gz
-doctest-corpus-stats.md
+# doctest-corpus-stats.md is tracked deliberately: it is counts-only (never
+# corpus text), and reviewing how the acceptance rate and refusal mix move is
+# part of reviewing a guardrail change. It is expected to change when the
+# integration suite runs; `make integration-test` refreshes it.
 
 # Prototype spikes are runnable but not part of the package build.
 prototypes/**/__pycache__/

--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -3275,3 +3275,45 @@ Fixed in the working tree. Host suite green (`SAGEMATH_MCP_PURE_PYTHON=1`):
 886 passed, lint clean. Full container suite against real SageMath 10.9:
 427 passed across the security/integration/coverage files, escape reproducer
 refused and no file written.
+
+## 62. Terminal module names pass the validator under a caller-bound root — defence in depth for item 61 — DONE
+
+The follow-up item 61 flagged. Item 61 closed the module-object pivot at the
+star-export screen; this closes the second half at the validator, so the object
+is refused even if some future path binds a module to a caller name again.
+
+The terminal-segment rule in `validate_module` (`security.py`) waved a forbidden
+parent through whenever it was the *terminal* segment of a chain whose root was
+not on the allowlist -- on the theory that a non-offered root means
+`<expr>.method`. That is false when the root is a bound module object:
+`dirichlet.free_module_element.sage.env.os` reached the real `os` module with
+`os` as the terminal, and `alias.system('id')` then ran a shell (item 61's
+escape).
+
+### Fix
+
+Only five forbidden parents are also real methods on a mathematical object --
+`trace`, `sh`, `operator`, `pari`, `oeis` (`A.trace()`, `(x+y).operator()`,
+`E.pari()`), the `_TERMINAL_METHOD_NAMES` set. Every other one -- `os`, `sys`,
+`subprocess`, `socket`, `shutil`, `pathlib`, `persist`, `cython`, `warnings`,
+`builtins`, ... -- has no method meaning, so a terminal occurrence is a module
+reference whatever the root is, and is now refused unconditionally. The five
+dual-use names keep their `object.method` exemption (one- or two-segment chains,
+and longer method-on-method chains not rooted at an offered module name); the
+genuine module paths `sage.misc.trace` / `sage.misc.sh` still fall through to the
+refusal. No mathematics is lost -- there is no `A.os()`.
+
+### How to verify
+
+`test_a_terminal_module_name_is_refused_under_any_root` (six pivots:
+`m.os`, `v.sys`, `g.env.subprocess`, `p.misc.persist`, `s.env.socket`,
+`d.a.b.sage.env.os`) and `test_dual_use_methods_still_pass` (`.trace()`,
+`.operator()`, `pi.operator`) in `tests/test_security_bypass.py`. All six pivots
+fail against the pre-fix validator, which is the point.
+
+### Status
+
+Fixed in the working tree. Host suite green (`SAGEMATH_MCP_PURE_PYTHON=1`):
+897 passed, lint clean. Full container suite against real SageMath 10.9:
+437 passed across the security/math-coverage/integration files, no accepted
+mathematics refused.

--- a/doctest-corpus-stats.md
+++ b/doctest-corpus-stats.md
@@ -1,0 +1,61 @@
+# Doctest corpus validation statistics
+
+The most important functional test of the security guardrails: every
+`sage:` example in the installed SageMath library, pushed through
+`preparse` + `validate_module`, asking whether this server would refuse
+the mathematics Sage itself documents. Generated on every run of
+`tests/test_sage_doctest_corpus.py`; counts only, never corpus text.
+
+- Generated: 2026-08-16 20:03:16 UTC
+- SageMath: 10.9 (`/home/sage/sage/local/var/lib/sage/venv-python3.12/lib/python3.12/site-packages/sage`)
+
+| Metric | Value |
+| --- | ---: |
+| Source files | 3,168 |
+| Docstrings | 60,094 |
+| Examples | 432,878 |
+| Accepted | 369,935 |
+| Refused | 4,493 |
+| Excluded (out of scope by design) | 58,268 |
+| Unparsed | 182 |
+| **Acceptance (in-scope)** | **98.8000%** |
+| Required acceptance | 98.50% |
+| Required accepted examples | 250,000 |
+
+## Refused, by rule
+
+In-scope mathematics a guardrail turned away, categorized by the rule
+that fired. Every rule here must appear in `DELIBERATE_RULES` with a
+ceiling, or `test_every_refusal_is_a_rule_we_meant_to_write` fails.
+
+| Count | Share of in-scope | Rule |
+| ---: | ---: | --- |
+| 2,083 | 0.5563% | `'X' is not offered: it spawns an external program, and this server does the same mathema` |
+| 1,929 | 0.5152% | `'X' is not a name this server offers` |
+| 213 | 0.0569% | `'X' is not defined` |
+| 130 | 0.0347% | `Access through 'X' is blocked ('X' is not permitted in Sage executions)` |
+| 69 | 0.0184% | `Access to 'X' is blocked: writing files is not available to caller code` |
+| 38 | 0.0101% | `Call to forbidden function 'X' is blocked` |
+| 17 | 0.0045% | `Call to forbidden attribute 'X' is blocked` |
+| 11 | 0.0029% | `Import statements are disabled for Sage executions` |
+| 2 | 0.0005% | `Access to forbidden function 'X' is blocked` |
+| 1 | 0.0003% | `Reference to forbidden name 'X' is blocked` |
+
+## Excluded, by capability
+
+Out of scope by design: doctests using capabilities this server does
+not offer (imports, persistence, filesystem, external interfaces, ...).
+Counted, not asserted over, and not part of the acceptance rate.
+
+| Count | Share of examples | Capability |
+| ---: | ---: | --- |
+| 30,219 | 6.9810% | `optional-tag` |
+| 19,149 | 4.4236% | `import` |
+| 2,257 | 0.5214% | `dunder` |
+| 1,915 | 0.4424% | `persistence` |
+| 1,327 | 0.3066% | `filesystem` |
+| 978 | 0.2259% | `display` |
+| 813 | 0.1878% | `repl-magic` |
+| 747 | 0.1726% | `interfaces` |
+| 706 | 0.1631% | `shell-or-eval` |
+| 157 | 0.0363% | `network` |

--- a/src/sagemath_mcp/security.py
+++ b/src/sagemath_mcp/security.py
@@ -1227,20 +1227,32 @@ def validate_module(
                     if segment not in policy.forbidden_attribute_parents:
                         continue
                     if index == last:
-                        # A module path is a dotted chain from an offered NAME:
-                        # `sage.env.os`, `desolvers.os`. A single-segment chain
-                        # is `<expr>.method` -- `(x+y).operator()` -- where the
-                        # root was a Call or BinOp, not a Name, so `segments[0]`
-                        # is the method, not a module. `operator` and `pari` are
-                        # offered names AND forbidden parents, so len>=2 is what
-                        # tells the module `operator` from the `.operator()`
-                        # method.
-                        module_path = len(segments) >= 2 and root in policy.allowed_names
-                        object_method = (
-                            len(segments) == 2 and segment in _TERMINAL_METHOD_NAMES
-                        )
-                        if not module_path or object_method:
-                            continue
+                        # Only five forbidden parents are ALSO ordinary methods
+                        # on a mathematical object -- trace, sh, operator, pari,
+                        # oeis (`A.trace()`, `(x+y).operator()`, `E.pari()`).
+                        # Every other one -- os, sys, subprocess, socket, shutil,
+                        # pathlib, persist, cython, warnings, builtins, ... -- has
+                        # no method meaning at all, so a terminal one is a module
+                        # reference WHATEVER the root is. The old rule waved it
+                        # through whenever the root was not offered, on the theory
+                        # that a non-allowlisted root meant `<expr>.method`. That
+                        # is false when the root is a bound *module object*:
+                        # `dirichlet.free_module_element.sage.env.os` reached the
+                        # real os module with `os` as the terminal, past this very
+                        # branch, and `alias.system('id')` then ran a shell (item
+                        # 61). The star-export screen no longer lets a module bind
+                        # to a caller name, but the validator refuses the pivot
+                        # too now -- the object should not be reachable either.
+                        if segment in _TERMINAL_METHOD_NAMES:
+                            # A plain object.method -- one or two segments -- or a
+                            # longer method-on-method chain not rooted at an
+                            # offered module name. The genuine module path
+                            # `sage.misc.trace` / `sage.misc.sh` (rooted at the
+                            # offered `sage`, three-plus segments) still falls
+                            # through to the refusal below.
+                            module_path = len(segments) >= 2 and root in policy.allowed_names
+                            if len(segments) <= 2 or not module_path:
+                                continue
                     elif index == 0 and caller_owned:
                         # The caller rebound a name that happens to be a
                         # forbidden parent. Only the ROOT is theirs -- a

--- a/tests/test_security_bypass.py
+++ b/tests/test_security_bypass.py
@@ -901,6 +901,50 @@ def test_a_star_import_cannot_hand_a_caller_a_module_object() -> None:
     assert result["ok"] is False
 
 
+# A terminal pure-module name (os, sys, ...) reached through a caller-bound root
+# was the second half of the item 61 escape: the validator treated it as a benign
+# `<object>.method` because the root was not on the allowlist. These never name a
+# method, so the validator now refuses them wherever the root came from -- the
+# defence-in-depth lock that does not depend on the star-export screen.
+TERMINAL_MODULE_PIVOTS = [
+    ("bound-root-os", "m = matrix([[1, 2], [3, 4]])\nm.os"),
+    ("bound-root-sys", "v = vector([1, 2])\nv.sys"),
+    ("bound-root-subprocess", "g = 1\ng.env.subprocess"),
+    ("bound-root-persist", "p = 2\np.misc.persist"),
+    ("bound-root-socket", "s = 3\ns.env.socket"),
+    ("deep-chain-os", "d = 1\nd.a.b.sage.env.os"),
+]
+
+
+@pytest.mark.parametrize(
+    ("case_id", "payload"), TERMINAL_MODULE_PIVOTS,
+    ids=[c for c, _ in TERMINAL_MODULE_PIVOTS],
+)
+def test_a_terminal_module_name_is_refused_under_any_root(case_id: str, payload: str) -> None:
+    """`<caller-bound>.os` is a module reference, not a method -- refuse it even
+    though the root is not on the allowlist (item 61 defence in depth)."""
+    with pytest.raises(SecurityViolation):
+        _validate(payload)
+
+
+# The five forbidden parents that ARE also real methods must keep working: the
+# fix must close the module pivot without refusing ordinary mathematics.
+DUAL_USE_METHODS_STILL_ALLOWED = [
+    ("matrix-trace", "matrix([[1, 2], [3, 4]]).trace()"),
+    ("expr-operator", "(x + y).operator()"),
+    ("bound-var-trace", "M = matrix([[1, 2], [3, 4]])\nM.trace()"),
+    ("allowlisted-root-operator", "pi.operator"),
+]
+
+
+@pytest.mark.parametrize(
+    ("case_id", "payload"), DUAL_USE_METHODS_STILL_ALLOWED,
+    ids=[c for c, _ in DUAL_USE_METHODS_STILL_ALLOWED],
+)
+def test_dual_use_methods_still_pass(case_id: str, payload: str) -> None:
+    _validate(payload)
+
+
 # --- Sage's own string-path primitives -----------------------------------------
 # The `operator` round blocked Python's attrgetter/methodcaller and left Sage's
 # equivalents in place, which is fixing the instance instead of the class. All


### PR DESCRIPTION
## Summary

Defence-in-depth follow-up to **item 61** (module-object star-import escape). Item 61 closed the pivot at the star-export screen; this closes the second half **at the AST validator**, so a module-object pivot is refused even if a module is bound to a caller name by some other path — matching the codebase's "the object should not be reachable either" philosophy.

## The gap

The terminal-segment rule in `validate_module` waved a forbidden parent through whenever it was the *terminal* segment of a chain whose root was **not on the allowlist**, on the theory that a non-offered root means `<expr>.method`. That is false when the root is a bound module object:

```python
from sage.modular.dims import *        # (pre-item-61) bound `dirichlet`, a module
_m = dirichlet.free_module_element.sage.env.os   # `os` terminal -> real os module
_m.system('id')                        # shell as the container user
```

`os` was the terminal segment, so the rule treated it as a benign method and skipped it.

## Fix

Only five forbidden parents are *also* real methods on a mathematical object — `trace`, `sh`, `operator`, `pari`, `oeis` (`A.trace()`, `(x+y).operator()`, `E.pari()`). Every other one — `os`, `sys`, `subprocess`, `socket`, `shutil`, `pathlib`, `persist`, `cython`, `warnings`, `builtins`, … — has no method meaning, so a terminal occurrence is a module reference **whatever the root is**, and is now refused unconditionally. The dual-use names keep their `object.method` exemption; the genuine module paths `sage.misc.trace` / `sage.misc.sh` still fall through to refusal. No mathematics is lost — there is no `A.os()`.

## Tests

- `test_a_terminal_module_name_is_refused_under_any_root` — six pivots (`m.os`, `v.sys`, `g.env.subprocess`, `p.misc.persist`, `s.env.socket`, `d.a.b.sage.env.os`); **all six fail against the pre-fix validator**, which is the point.
- `test_dual_use_methods_still_pass` — `.trace()`, `.operator()`, `pi.operator` still accepted.

## Verification

- Host (`SAGEMATH_MCP_PURE_PYTHON=1`): 897 passed, lint clean.
- Container, real SageMath 10.9: 437 passed across the security / math-coverage / integration files — no accepted mathematics refused.

REVIEW_ACTIONS item 62 records the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)