### PR TITLE
Reduce doctest-corpus refusals safely (items 63-65)

### DIFF
--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -3317,3 +3317,58 @@ Fixed in the working tree. Host suite green (`SAGEMATH_MCP_PURE_PYTHON=1`):
 897 passed, lint clean. Full container suite against real SageMath 10.9:
 437 passed across the security/math-coverage/integration files, no accepted
 mathematics refused.
+
+## 63. Re-admit modules that were dirty only for a re-exported module object — usability — DONE
+
+Reduces refusals safely. Item 61 closed the module-object pivot by failing the
+*whole* star module when any export was a module object. That was correct but
+costly: `sage.rings.polynomial.real_roots`, `sage.modular.dims` and the `pbori`
+Boolean-polynomial modules are ordinary mathematics dirtied by a single
+re-exported module (`time`, `dirichlet`, `operator`, `sage`), and failing them
+whole cost the corpus 278 documented examples.
+
+### Design
+
+`_star_export_screen` now **drops** a module-object export from the screened
+names instead of failing the module, and does so *before* the name-based screens
+so a re-export named `operator` or `sage` (both forbidden parents) is dropped
+rather than treated as a failure. Everything else still fails the module whole,
+so clean-as-a-whole holds for every value a caller can actually bind.
+
+This is a deliberate, reviewed relaxation of the "clean as a whole, never a
+filtered subset" invariant to "clean as a whole *except* module-object names are
+dropped." It is safe on three independent grounds: (1) a module object is the
+only *pivot* category -- a bound class or function is bounded by the AST rules,
+a bound module is a walk into the whole tree; (2) the star expansion binds the
+explicit screened names, so a dropped name is never imported; (3) item 62
+refuses the pivot at the validator even if one were bound. The residual
+capability-blindness (a clean-screening value that does something the screen
+cannot see) is unchanged from the existing clean modules -- `sage.libs.ecl`
+still stays out by curation, not by the screen, because `EclObject` evaluates
+Lisp.
+
+Four modules re-admitted: `real_roots`, `dims`, `pbori.pbori`, `pbori`. The
+curated `CANDIDATE_MODULES` list is still the gate; the screen only decides
+whether a candidate qualifies.
+
+### How to verify
+
+Unit (host): `test_star_export_screen_drops_a_re_exported_module_object` and
+`test_star_export_screen_still_fails_whole_for_a_non_module_danger`
+(`tests/test_sage_worker.py`). Integration, real SageMath 10.9:
+`test_a_star_import_cannot_hand_a_caller_a_module_object` (unchanged guarantee --
+no caller binds a module, the item-61 pivot still refused) and
+`test_a_module_dropped_star_import_still_computes` (the re-admitted mathematics
+runs, the dropped module object stays unbound) in `tests/test_security_bypass.py`;
+`test_the_star_exports_match_this_sage` (`tests/test_integration.py`).
+
+### Measured
+
+Corpus sweep: refusals 4,493 -> 4,215 (-278), acceptance 98.8000% -> ~98.87%.
+Recovered names are Boolean-polynomial and real-root mathematics
+(`real_roots`, `mk_ibpi`, the `pbori` classes) that Sage documents and this
+server previously turned away for a sibling module object.
+
+### Status
+
+Fixed in the working tree; verified host + container. Builds on item 62.

--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -3372,3 +3372,84 @@ server previously turned away for a sibling module object.
 ### Status
 
 Fixed in the working tree; verified host + container. Builds on item 62.
+
+## 64. Offer `set_verbose` as a no-op, and keep caller shims alive across reseals — usability — DONE
+
+`set_verbose(2)` opens many doctests as setup noise; it only sets a global
+chattiness level, which has no surface over MCP (results are strings, progress
+is the streaming tool's job), so refusing it broke the whole example for
+nothing. It is now offered as a no-op.
+
+### Design
+
+A small `_CALLER_SHIMS` map holds the callables offered to caller code in place
+of a scrubbed Sage global -- `attrcall` (the guarded wrapper, item 59) and
+`set_verbose` (a no-op). They are (re)installed by `_install_caller_shims` after
+*every* scrub: at startup and after every reseal. Fixing that also fixed a
+latent bug -- the scrub removes `attrcall` by name, and nothing put it back, so
+`attrcall` silently stopped working after the first specialised-tool call (which
+reseals the namespace).
+
+`set_verbose` is offered outright via `_OFFERED_SHIM_NAMES`: it is excluded from
+the withheld snapshot and unioned into the validator's allowed set on the caller
+path. `attrcall` is deliberately NOT offered -- it stays refused bare and
+permitted only as a screened literal call. The real `set_verbose` remains
+scrubbed by provenance (its sibling `set_verbose_files` writes to a path); only
+the harmless no-op is exposed.
+
+### How to verify
+
+`test_set_verbose_is_offered_as_a_noop` and `test_caller_shims_survive_a_reseal`
+(`tests/test_sage_worker.py`); `test_the_caller_allowlist_matches_this_sage`
+updated to exempt both shims (`tests/test_integration.py`).
+
+### Measured
+
+Corpus sweep (modelled the way the worker offers it): the `set_verbose`
+refusals, ~57 of the "spawns an external program" bucket, are gone.
+
+### Status
+
+Fixed in the working tree; verified host + container.
+
+## 65. Auto-declare symbol-shaped free names in evaluate_sage — usability — DONE
+
+SageMath's SR declares a symbol when it parses one out of a string; the
+specialised tools follow that contract, but `evaluate_sage` runs real Python
+where `w + 1` is a NameError, so it refused undeclared symbol-shaped names and
+told the caller to `var()` them. This brings the two paths together.
+
+### Design
+
+On the caller path only, `_split_code` computes the symbol-shaped free names the
+validator would otherwise refuse -- a letter with an optional index, or a Greek
+name (`w`, `x_2`, `k1`, `alpha`) -- hands them to the validator as allowed, and
+`_execute` binds each as `var(name)` before running. The shape is deliberately
+narrow, so a multi-letter typo (`sinn`, `foobar`) stays an error rather than a
+silent empty symbol. Three guards keep it honest: a name already offered
+(allowlisted, a session variable, a shim, or bound in the snippet) is left
+alone, so `w = 5` set earlier survives; a withheld name is never declared; and a
+name that is *called* and has a native equivalent keeps its redirect -- `r` is a
+radius bare but the R interface as `r(...)`, the same split the validator draws.
+
+Generated templates are untouched: they run under the trusted policy with the
+allowlist off and declare their own symbols through the prelude's `_SymbolLocals`.
+
+### How to verify
+
+`test_symbol_shaped_free_names_pass_validation`,
+`test_symbol_auto_declaration_does_not_shadow_a_session_variable`, and
+`test_symbol_auto_declaration_computes_and_respects_session` (real Sage) in
+`tests/test_sage_worker.py`. The corpus sweep now models the auto-declaration
+(as it already models `_`, star-exports and injection), so the stats reflect
+what evaluate_sage really accepts.
+
+### Measured
+
+Corpus sweep: the "is not defined" bucket (213 refusals -- `r`, `x0`, `f`, `s`)
+goes to zero. Combined with items 63 and 64, refusals 4,493 -> 3,936 (-557) and
+acceptance 98.80% -> 98.9488%.
+
+### Status
+
+Fixed in the working tree; verified host + container.

--- a/doctest-corpus-stats.md
+++ b/doctest-corpus-stats.md
@@ -6,7 +6,7 @@ The most important functional test of the security guardrails: every
 the mathematics Sage itself documents. Generated on every run of
 `tests/test_sage_doctest_corpus.py`; counts only, never corpus text.
 
-- Generated: 2026-08-16 20:03:16 UTC
+- Generated: 2026-08-16 20:45:58 UTC
 - SageMath: 10.9 (`/home/sage/sage/local/var/lib/sage/venv-python3.12/lib/python3.12/site-packages/sage`)
 
 | Metric | Value |
@@ -14,11 +14,11 @@ the mathematics Sage itself documents. Generated on every run of
 | Source files | 3,168 |
 | Docstrings | 60,094 |
 | Examples | 432,878 |
-| Accepted | 369,935 |
-| Refused | 4,493 |
+| Accepted | 370,492 |
+| Refused | 3,936 |
 | Excluded (out of scope by design) | 58,268 |
 | Unparsed | 182 |
-| **Acceptance (in-scope)** | **98.8000%** |
+| **Acceptance (in-scope)** | **98.9488%** |
 | Required acceptance | 98.50% |
 | Required accepted examples | 250,000 |
 
@@ -30,9 +30,8 @@ ceiling, or `test_every_refusal_is_a_rule_we_meant_to_write` fails.
 
 | Count | Share of in-scope | Rule |
 | ---: | ---: | --- |
-| 2,083 | 0.5563% | `'X' is not offered: it spawns an external program, and this server does the same mathema` |
-| 1,929 | 0.5152% | `'X' is not a name this server offers` |
-| 213 | 0.0569% | `'X' is not defined` |
+| 2,026 | 0.5411% | `'X' is not offered: it spawns an external program, and this server does the same mathema` |
+| 1,642 | 0.4385% | `'X' is not a name this server offers` |
 | 130 | 0.0347% | `Access through 'X' is blocked ('X' is not permitted in Sage executions)` |
 | 69 | 0.0184% | `Access to 'X' is blocked: writing files is not available to caller code` |
 | 38 | 0.0101% | `Call to forbidden function 'X' is blocked` |

--- a/scripts/generate_star_exports.py
+++ b/scripts/generate_star_exports.py
@@ -49,6 +49,15 @@ CANDIDATE_MODULES: tuple[str, ...] = (
     "sage.modules.fp_graded.module",                          # 14
     "sage.combinat.dlx",                                      # 13
     "sage.rings.fraction_field_FpT",                          # 15
+    # Re-admitted under item 63's drop-module-objects screen: each was dirty for
+    # a re-exported module object alone (`real_roots`/`dims` were item-60 modules
+    # item 61 dropped whole; `pbori` re-exports `operator`/`sage`). The module
+    # objects are dropped, the mathematics is kept. Corpus star-import weight in
+    # the comment. `sage.libs.ecl` stays out despite screening clean -- EclObject
+    # evaluates Lisp, which no screen can see; curation, not the screen, keeps it
+    # excluded.
+    "sage.rings.polynomial.pbori.pbori",                      # 38
+    "sage.rings.polynomial.pbori",                            # 11
 )
 
 HEADER = '''"""The `from <module> import *` statements caller code is allowed to keep.

--- a/src/sagemath_mcp/_sage_worker.py
+++ b/src/sagemath_mcp/_sage_worker.py
@@ -18,6 +18,8 @@ from sagemath_mcp.allowlist import ALLOWED_CALLER_NAMES
 from sagemath_mcp.security import (
     SECURITY_POLICY,
     _bound_names,
+    _looks_like_an_undeclared_symbol,
+    _native_equivalent,
     attrcall_attribute_violation,
     check_source_length,
     injects_session_names,
@@ -70,6 +72,97 @@ def _guarded_attrcall(name: object, *args: Any, **kwds: Any) -> Any:
     return _sage_attrcall(name, *args, **kwds)
 
 
+def _noop_set_verbose(*args: Any, **kwargs: Any) -> None:
+    """`set_verbose` offered to caller code as a harmless no-op.
+
+    The real one lives in `sage.misc.verbose`, scrubbed by provenance because a
+    sibling (`set_verbose_files`) writes to a caller-chosen path. `set_verbose`
+    itself only sets a global chattiness level, which has no surface over MCP --
+    results come back as strings and progress is the streaming tool's job. It is
+    offered as a no-op so a doctest that opens with `set_verbose(2)` runs instead
+    of being refused for setup noise. See REVIEW_ACTIONS item 64.
+    """
+    return None
+
+
+# Callables offered to caller code in place of a scrubbed Sage global. The scrub
+# removes them by name, so they are (re)installed AFTER it -- at startup and
+# after every reseal. Without the re-install `attrcall` silently stopped working
+# after the first specialised-tool call, which reseals the namespace.
+_CALLER_SHIMS: dict[str, Any] = {
+    "attrcall": _guarded_attrcall,
+    "set_verbose": _noop_set_verbose,
+}
+# Of those, the names a caller may READ freely, bare and in any position.
+# `attrcall` is deliberately NOT here: it is refused bare and permitted only as a
+# screened literal call (item 59), so it stays subject to deny-by-default.
+# `set_verbose` is harmless, so it is offered outright.
+_OFFERED_SHIM_NAMES: frozenset[str] = frozenset({"set_verbose"})
+
+
+def _install_caller_shims(ns: dict[str, Any]) -> None:
+    """Put the caller shims back after a scrub has removed them."""
+    for name, shim in _CALLER_SHIMS.items():
+        ns[name] = shim
+
+
+def _auto_declarable_symbols(
+    module: ast.Module, offered: frozenset[str] | set[str], withheld: frozenset[str] | set[str]
+) -> frozenset[str]:
+    """Symbol-shaped free names evaluate_sage should declare, not refuse.
+
+    SageMath's SR declares a symbol when it parses one out of a string --
+    `SR("a*b")` creates `a` and `b` -- and the specialised tools follow that
+    contract. `evaluate_sage` runs real Python, where `w + 1` is a NameError, and
+    so refused these with "declare it first with var('w')". This closes that gap
+    for the same narrow, typo-guarded shape the tools use: a letter with an
+    optional index, or a Greek name (`w`, `x_2`, `k1`, `alpha`). `sinn`, `foobar`
+    and every multi-letter name stay refused, so a typo is still an error, not a
+    silent empty symbol.
+
+    A name already offered -- allowlisted, a session variable, a shim, or bound
+    in this snippet -- is left alone, so a caller who set `w = 5` earlier keeps
+    it. A withheld name is never declared: it holds something real. And a name
+    that is *called* and has a native equivalent keeps its redirect -- `r` is a
+    radius as a bare symbol but the R interface as `r(...)`, exactly the
+    distinction the validator already draws.
+    """
+    called = {
+        id(node.func)
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    result: set[str] = set()
+    for node in ast.walk(module):
+        if not (isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)):
+            continue
+        name = node.id
+        if name in offered or name in withheld:
+            continue
+        if not _looks_like_an_undeclared_symbol(name):
+            continue
+        if id(node) in called and _native_equivalent(name) is not None:
+            continue
+        result.add(name)
+    return frozenset(result)
+
+
+def _declare_symbols(namespace: dict[str, Any], names: frozenset[str]) -> None:
+    """Bind each auto-declarable symbol as `var(name)`, unless already present.
+
+    Session state wins: a name the caller already assigned is not overwritten
+    with a symbol. Uses the namespace's own `var`, so the pure-Python harness
+    (which has none) simply skips -- the feature is Sage's.
+    """
+    var = namespace.get("var")
+    if var is None:
+        return
+    for name in names:
+        if name not in namespace:
+            with contextlib.suppress(Exception):
+                namespace[name] = var(name)
+
+
 def _build_namespace() -> dict[str, Any]:
     # NOTE: Each worker keeps its own global namespace. We allow a single
     # preload statement so sessions can bootstrap Sage or the lightweight math
@@ -108,8 +201,8 @@ def _build_namespace() -> dict[str, Any]:
     # the name screens its string against those same rules first -- so the
     # validator can permit the literal spelling SageMath's own doctests use 155
     # times, and even code that somehow reached the object with a computed
-    # string gets a ValueError, not a file.
-    ns["attrcall"] = _guarded_attrcall
+    # string gets a ValueError, not a file. Installed with the other shims.
+    _install_caller_shims(ns)
     if not PURE_PYTHON:
         # Sage's REPL predefines x and importing sage.all does not even provide
         # that. The other three are this server's own convention, matching the
@@ -521,6 +614,10 @@ def _reseal_namespace(ns: dict[str, Any], introduced: frozenset[str] = frozenset
     """
     _strip_forbidden_modules(ns)
     _strip_dangerous_sage_names(ns)
+    # The scrub removes the shims by name (`attrcall`, `set_verbose` are on the
+    # denylist), so put them back -- otherwise they work at startup and vanish
+    # after the first specialised-tool call, which reseals.
+    _install_caller_shims(ns)
     # A name trusted code introduced is not the caller's, whatever they bound
     # earlier. Without this a caller can reserve the templates' internals in
     # dead code -- `if False: _fig = 1` -- and collect the objects a later tool
@@ -530,7 +627,9 @@ def _reseal_namespace(ns: dict[str, Any], introduced: frozenset[str] = frozenset
     global _WITHHELD_NAMES
     _WITHHELD_NAMES = frozenset(
         name for name in ns
-        if name not in ALLOWED_CALLER_NAMES and name not in _CALLER_BOUND_NAMES
+        if name not in ALLOWED_CALLER_NAMES
+        and name not in _CALLER_BOUND_NAMES
+        and name not in _OFFERED_SHIM_NAMES
     )
 
 
@@ -761,7 +860,10 @@ def _withheld_names(ns: dict[str, Any]) -> frozenset[str]:
     up the caller's own variables: they live in this same namespace, so `total`
     would be withheld on the call after the one that created it.
     """
-    return frozenset(n for n in ns if n not in ALLOWED_CALLER_NAMES)
+    return frozenset(
+        n for n in ns
+        if n not in ALLOWED_CALLER_NAMES and n not in _OFFERED_SHIM_NAMES
+    )
 
 
 def _split_code(
@@ -802,9 +904,28 @@ def _split_code(
         module = rewrite_permitted_imports(
             module, offered=ALLOWED_CALLER_NAMES, policy=policy
         )
+    # Symbol-shaped free names evaluate_sage would otherwise refuse are declared
+    # as symbols instead (caller code only -- generated templates have the
+    # allowlist off and declare their own). Computed before validation and handed
+    # in as allowed, so the validator that used to refuse them now passes them,
+    # and _execute binds each as var(name) before running.
+    auto_symbols: frozenset[str] = frozenset()
+    if not trusted:
+        offered = (
+            set(session_names)
+            | set(_OFFERED_SHIM_NAMES)
+            | set(ALLOWED_CALLER_NAMES)
+            | _bound_names(module)
+        )
+        auto_symbols = _auto_declarable_symbols(module, offered, withheld)
+    # The offered shims (`set_verbose`) are readable like an allowlisted name;
+    # they live in the namespace as no-ops, not on the generated allowlist, so
+    # they are offered here instead. `attrcall` is not among them -- it stays a
+    # screened-call-only exemption.
     validate_module(
         module, code=code, policy=policy,
-        extra_allowed_names=session_names, withheld_names=withheld,
+        extra_allowed_names=frozenset(session_names) | _OFFERED_SHIM_NAMES | auto_symbols,
+        withheld_names=withheld,
     )
     bound_here: frozenset[str] = frozenset()
     if trusted:
@@ -815,8 +936,10 @@ def _split_code(
     else:
         # Approved, so what it binds is readable on later calls in this session
         # -- except a name that is already live and not offered, which the
-        # caller is shadowing rather than creating.
-        _CALLER_BOUND_NAMES.update(_bound_names(module) - withheld)
+        # caller is shadowing rather than creating. An auto-declared symbol is
+        # the caller's from now on too: the var() binding persists in the
+        # namespace, so the session should keep offering the name.
+        _CALLER_BOUND_NAMES.update((_bound_names(module) | auto_symbols) - withheld)
     # `A.inject_variables()` creates names while the snippet runs. The validator
     # lets the snippet read them; this tells _execute to find out what they were,
     # so the *next* call can read them too -- which is what makes a session a
@@ -833,9 +956,9 @@ def _split_code(
         ast.fix_missing_locations(prefix)
         ast.fix_missing_locations(tail)
         return SimpleNamespace(bound_here=bound_here, prefix=prefix, tail=tail,
-                               is_expr=True, injects=injects)
+                               is_expr=True, injects=injects, auto_symbols=auto_symbols)
     return SimpleNamespace(bound_here=bound_here, prefix=module, tail=None,
-                           is_expr=False, injects=injects)
+                           is_expr=False, injects=injects, auto_symbols=auto_symbols)
 
 
 
@@ -921,6 +1044,10 @@ def _execute(
 
     before_trusted = frozenset(namespace) if trusted else frozenset()
     before_execution = set(namespace) if compiled.injects and not trusted else set()
+    # Declare the symbol-shaped free names the validator approved, so `w + 1`
+    # runs instead of raising NameError. Session state is preserved: a name the
+    # caller already assigned is not overwritten.
+    _declare_symbols(namespace, getattr(compiled, "auto_symbols", frozenset()))
     try:
         with contextlib.redirect_stdout(stdout_buffer or io.StringIO()):
             exec(compile(compiled.prefix, "<sagecell>", "exec"), namespace)

--- a/src/sagemath_mcp/_sage_worker.py
+++ b/src/sagemath_mcp/_sage_worker.py
@@ -454,19 +454,26 @@ def _star_export_screen(
     for name in exported:
         if not isinstance(name, str) or name.startswith("_") or not name.isidentifier():
             return None
+        value = vars(module).get(name)
+        # A re-exported module object is DROPPED, not a reason to fail the module.
+        # `dirichlet` re-exports `sage.modules.free_module_element`, which reaches
+        # `sage.env.os`, so binding it is a pivot into the whole tree -- but the
+        # star expansion binds the explicit screened names, so a dropped name is
+        # never imported, and item 62 refuses the pivot at the validator even if
+        # one were. That makes a module object the one danger category it is safe
+        # to filter out: item 61 failed the whole module for it (losing
+        # `real_roots`, `dims`, `pbori` for a single `time`/`operator`), and this
+        # keeps the mathematics while still never handing a caller a module. Every
+        # OTHER danger still fails the module whole (clean-as-a-whole), because a
+        # module is the ONLY pivot -- a bound class or function is bounded by the
+        # AST rules. Checked before the name-based screens so a re-export named
+        # `operator` or `sage` (both forbidden parents) is dropped, not a failure.
+        # See REVIEW_ACTIONS item 63.
+        if isinstance(value, ModuleType):
+            continue
         if name in dangerous or name in forbidden:
             return None
         if any(name.startswith(prefix) for prefix in policy.forbidden_attribute_prefixes):
-            return None
-        value = vars(module).get(name)
-        # A re-exported module object is a pivot, not a leaf: `dirichlet` re-exports
-        # `sage.modules.free_module_element`, which reaches `sage.env.os`, and the
-        # validator's terminal-segment rule then treats `<caller_alias>.os` as a
-        # benign method and lets the caller bind the real `os` module. Provenance
-        # cannot catch this -- a module has `__name__`, not `__module__`, so the
-        # home check below reads `""` and passes -- so reject the value by type. A
-        # module vetted "clean as a whole" has no business handing back a module.
-        if isinstance(value, ModuleType):
             return None
         home = getattr(value, "__module__", "") or ""
         if isinstance(home, str) and any(

--- a/src/sagemath_mcp/star_exports.py
+++ b/src/sagemath_mcp/star_exports.py
@@ -26,6 +26,30 @@ from __future__ import annotations
 
 STAR_EXPORTS: dict[str, frozenset[str]] = {
 
+    "sage.rings.polynomial.real_roots": frozenset({
+        "AA", "FreeModule", "MatrixSpace", "PolynomialRing", "PrecisionError", "QQ",
+        "RDF", "RIF", "RR", "RealField", "RealIntervalField", "ZZ",
+        "bernstein_down", "bernstein_expand", "bernstein_polynomial_factory",
+        "bernstein_polynomial_factory_ar", "bernstein_polynomial_factory_intlist",
+        "bernstein_polynomial_factory_ratlist", "bernstein_up", "binomial",
+        "bitsize_doctest", "cl_maximum_root", "cl_maximum_root_first_lambda",
+        "cl_maximum_root_local_max", "context", "copy", "de_casteljau_doublevec",
+        "de_casteljau_intvec", "degree_reduction_next_size", "denominator",
+        "dprod_imatrow_vec", "dr_cache", "factorial", "get_realfield_rndu",
+        "have_same_parent", "infinity", "interval_bernstein_polynomial",
+        "interval_bernstein_polynomial_float",
+        "interval_bernstein_polynomial_integer", "intvec_to_doublevec", "island",
+        "linear_map", "lmap", "max_abs_doublevec", "max_bitsize_intvec_doctest",
+        "maximum_root_first_lambda", "maximum_root_local_max",
+        "min_max_delta_intvec", "min_max_diff_doublevec", "min_max_diff_intvec",
+        "mk_context", "mk_ibpf", "mk_ibpi", "numerator", "ocean", "parent",
+        "precompute_degree_reduction_cache", "prod", "pseudoinverse", "randstate",
+        "rational_root_bounds", "real_roots", "realfield_rndu_cache",
+        "relative_bounds", "reverse_intvec", "root_bounds", "rr_gap",
+        "scale_intvec_var", "split_for_targets", "subsample_vec_doctest",
+        "taylor_shift1_intvec", "to_bernstein", "to_bernstein_warp", "vector",
+        "warp_map", "wordsize_rational"
+    }),
     "sage.matroids.lean_matrix": frozenset({
         "BinaryMatrix", "GF", "GenericMatrix", "LeanMatrix", "PlusMinusOneMatrix",
         "QQ", "QuaternaryMatrix", "RationalMatrix", "TernaryMatrix", "ZZ",
@@ -54,6 +78,13 @@ STAR_EXPORTS: dict[str, frozenset[str]] = {
         "KostkaFoulkesPolynomial", "SemistandardSkewTableaux", "SkewPartitions",
         "ZS1_iterator", "ZZ", "compat", "dom", "kfpoly", "kfpoly_skew", "polygen",
         "riggings", "schur_to_hl", "weight"
+    }),
+    "sage.modular.dims": frozenset({
+        "ArithmeticSubgroup", "CO_delta", "CO_nu", "CohenOesterle", "Gamma0",
+        "Gamma1", "GammaH_class", "Integer", "IntegerModRing", "Mod",
+        "dimension_cusp_forms", "dimension_eis", "dimension_modular_forms",
+        "dimension_new_cusp_forms", "eisen", "factor", "frac", "is_prime", "prod",
+        "sturm_bound", "valuation"
     }),
     "sage.schemes.elliptic_curves.weierstrass_morphism": frozenset({
         "EllipticCurve", "EllipticCurveHom", "Integer", "PolynomialRing",
@@ -91,6 +122,39 @@ STAR_EXPORTS: dict[str, frozenset[str]] = {
         "Fp_FpT_coerce", "FractionField_1poly_field", "Polyring_FpT_coerce", "ZZ",
         "ZZ_FpT_coerce", "have_same_parent", "parent", "revop", "rich_to_bool",
         "rich_to_bool_sgn", "richcmp", "richcmp_not_equal", "unpickle_FpT_element"
+    }),
+    "sage.rings.polynomial.pbori.pbori": frozenset({
+        "BooleConstant", "BooleSet", "BooleSetIterator", "BooleanMonomial",
+        "BooleanMonomialIterator", "BooleanMonomialMonoid",
+        "BooleanMonomialVariableIterator", "BooleanMulAction", "BooleanPolynomial",
+        "BooleanPolynomialEntry", "BooleanPolynomialIdeal",
+        "BooleanPolynomialIterator", "BooleanPolynomialRing",
+        "BooleanPolynomialVector", "BooleanPolynomialVectorIterator",
+        "CCuddNavigator", "FGLMStrategy", "FieldIdeal", "GF", "GroebnerStrategy",
+        "Integer", "MPolynomialIdeal", "Monoid_class", "Monomial",
+        "MonomialConstruct", "MonomialFactory", "OrderCode", "Polynomial",
+        "PolynomialConstruct", "PolynomialFactory", "PolynomialRing",
+        "PolynomialRing_generic", "ReductionStrategy", "Sequence", "TermOrder",
+        "TermOrder_from_pb_order", "UniqueRepresentation", "Variable",
+        "VariableBlock", "VariableConstruct", "VariableFactory",
+        "add_up_polynomials", "block_dlex", "block_dp_asc", "bytes_to_str",
+        "coerce_binop", "contained_vars", "current_randstate", "dlex", "dp",
+        "dp_asc", "easy_linear_factors", "gauss_on_polys", "get_var_mapping",
+        "have_same_parent", "if_then_else", "interpolate",
+        "interpolate_smallest_lex", "inv_order_dict", "ll_red_nf_noredsb",
+        "ll_red_nf_noredsb_single_recursive_call", "ll_red_nf_redsb", "lp",
+        "map_every_x_to_x_plus_one", "mod_mon_set", "mod_var_set",
+        "mult_fact_sim_C", "nf3", "order_dict", "order_mapping", "parallel_reduce",
+        "parent", "random_set", "recursively_insert", "red_tail", "revop",
+        "rich_to_bool", "rich_to_bool_sgn", "richcmp", "richcmp_not_equal", "rings",
+        "set_random_seed", "str_to_bytes", "substitute_variables", "top_index",
+        "unpickle_BooleanPolynomial", "unpickle_BooleanPolynomial0",
+        "unpickle_BooleanPolynomialRing", "zeros"
+    }),
+    "sage.rings.polynomial.pbori": frozenset({
+        "AlternatingBlock", "Block", "HigherOrderBlock", "Monomial", "Polynomial",
+        "Ring", "Variable", "all_monomials_of_degree_d", "declare_ring",
+        "groebner_basis", "load_file", "normal_form", "power_set"
     }),
 }
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -637,20 +637,28 @@ async def test_the_caller_allowlist_matches_this_sage():
     """
     import math
 
-    from sagemath_mcp._sage_worker import _build_namespace, _restricted_builtins
+    from sagemath_mcp._sage_worker import (
+        _CALLER_SHIMS,
+        _build_namespace,
+        _restricted_builtins,
+    )
     from sagemath_mcp.allowlist import ALLOWED_CALLER_NAMES
 
     namespace = _build_namespace()
     live_including_dunders = set(namespace) | set(_restricted_builtins())
 
-    # `attrcall` is deliberately live and deliberately off the allowlist: the
-    # namespace holds the worker's *guarded* wrapper (item 59), the validator
-    # permits exactly one spelling of it -- the call whose literal passes the
-    # attribute screen -- and every other read is refused by the forbidden-name
-    # rule itself, which consults neither the allowlist nor the caller's
-    # bindings. It is the one name whose protection does not depend on the gap
-    # below being empty, so it is excluded rather than allowlisted.
-    guarded = frozenset({"attrcall"})
+    # The caller shims are deliberately live and deliberately off the allowlist,
+    # because they replace a scrubbed Sage global with a safe stand-in rather
+    # than an allowlisted object (item 64):
+    #   `attrcall`     -- the worker's *guarded* wrapper (item 59). The validator
+    #                     permits exactly one spelling, the screened literal call;
+    #                     every other read is refused by the forbidden-name rule,
+    #                     which consults neither the allowlist nor the bindings.
+    #   `set_verbose`  -- a no-op, offered outright (harmless) via
+    #                     `_OFFERED_SHIM_NAMES`, not through the generated list.
+    # Their protection does not depend on the gap below being empty, so they are
+    # excluded rather than allowlisted.
+    guarded = frozenset(_CALLER_SHIMS)
 
     # What is live but not allowlisted must be dunders and nothing else. A
     # caller binding is trusted without consulting the allowlist, so anything

--- a/tests/test_sage_doctest_corpus.py
+++ b/tests/test_sage_doctest_corpus.py
@@ -50,6 +50,7 @@ from pathlib import Path
 
 import pytest
 
+from sagemath_mcp._sage_worker import _OFFERED_SHIM_NAMES, _auto_declarable_symbols
 from sagemath_mcp.allowlist import ALLOWED_CALLER_NAMES
 from sagemath_mcp.config import SageSettings
 from sagemath_mcp.security import (
@@ -348,9 +349,18 @@ def harvest(paths: list[Path]) -> Harvest:
                     result.excluded += 1
                     result.reasons[f"excluded:{label}"] += 1
                     continue
+                # Model the two evaluate_sage niceties the worker adds and this
+                # static walk otherwise misses (items 64/65), so the sweep counts
+                # what the server really accepts: `set_verbose` and the other
+                # offered shims, and symbol-shaped free names auto-declared as
+                # var() rather than refused.
+                offered = frozenset(bound) | _OFFERED_SHIM_NAMES
+                offered |= _auto_declarable_symbols(
+                    module, offered | ALLOWED_CALLER_NAMES, frozenset()
+                )
                 try:
                     validate_module(
-                        module, code=prepared, extra_allowed_names=frozenset(bound),
+                        module, code=prepared, extra_allowed_names=offered,
                         session_injects_names=session_injected,
                     )
                     result.accepted += 1

--- a/tests/test_sage_worker.py
+++ b/tests/test_sage_worker.py
@@ -864,15 +864,19 @@ def test_star_export_screen_rejects_a_re_exported_dangerous_object(monkeypatch):
     assert _sage_worker._star_export_screen("fake.reexport") is None
 
 
-def test_star_export_screen_rejects_a_re_exported_module_object(monkeypatch):
-    """A module object handed back by a star import is a pivot, not a leaf.
+def test_star_export_screen_drops_a_re_exported_module_object(monkeypatch):
+    """A module object handed back by a star import is a pivot, and is DROPPED
+    from the screened names rather than failing the whole module.
 
     `sage.modular.dims` re-exported the `sage.modular.dirichlet` module, which
-    reaches `sage.env.os`, and the validator's terminal-segment rule then let a
-    caller bind the real `os` and call `.system()`. Provenance cannot catch it:
-    a module has `__name__`, not `__module__`, so the home check reads "" and
-    passes. The screen must reject a module-object export by type. See
-    REVIEW_ACTIONS item 61.
+    reaches `sage.env.os`; binding it let a caller pivot to the real `os` (the
+    item 61 escape). Item 61 failed the whole module for it, which cost the
+    mathematics in `real_roots`/`dims`/`pbori` for a single module object. Item
+    63 drops the module-object name instead: the expansion binds only the
+    screened names, so a dropped name is never imported, and item 62 refuses the
+    pivot at the validator even if one were. The math names survive; the module
+    does not. A re-export whose NAME is a forbidden parent (`operator`, `sage`)
+    is dropped too, which is why the type check runs before the name screens.
     """
     import sys
     import types
@@ -880,15 +884,39 @@ def test_star_export_screen_rejects_a_re_exported_module_object(monkeypatch):
     from sagemath_mcp import _sage_worker
 
     pivot = types.ModuleType("fake.pivot")
-    pivot.__all__ = ["Widget", "submodule"]
+    # `operator` is both a module object AND a forbidden-parent name: it must be
+    # dropped by the type check before the name screen can fail the module.
+    pivot.__all__ = ["Widget", "submodule", "operator"]
     pivot.Widget = type("Widget", (), {})
     pivot.Widget.__module__ = "fake.pivot"
-    # A perfectly ordinary-looking re-export -- but it is a module, and a bound
-    # module object is a pivot into whatever it re-exports.
     pivot.submodule = types.ModuleType("some.other.module")
+    pivot.operator = types.ModuleType("operator")
     monkeypatch.setitem(sys.modules, "fake.pivot", pivot)
 
-    assert _sage_worker._star_export_screen("fake.pivot") is None
+    screened = _sage_worker._star_export_screen("fake.pivot")
+    assert screened == frozenset({"Widget"})
+    assert "submodule" not in screened
+    assert "operator" not in screened
+
+
+def test_star_export_screen_still_fails_whole_for_a_non_module_danger(monkeypatch):
+    """Only module objects are dropped; every other danger still fails the module
+    whole, so clean-as-a-whole holds for everything a bound value can reach."""
+    import sys
+    import types
+
+    from sagemath_mcp import _sage_worker
+
+    dirty = types.ModuleType("fake.stilldirty")
+    dirty.__all__ = ["Widget", "submodule", "save_thing"]  # save* is a write prefix
+    dirty.Widget = type("Widget", (), {})
+    dirty.Widget.__module__ = "fake.stilldirty"
+    dirty.submodule = types.ModuleType("some.other.module")  # dropped
+    dirty.save_thing = lambda: None                          # fails the module
+    dirty.save_thing.__module__ = "fake.stilldirty"
+    monkeypatch.setitem(sys.modules, "fake.stilldirty", dirty)
+
+    assert _sage_worker._star_export_screen("fake.stilldirty") is None
 
 
 def test_star_export_screen_returns_none_for_an_unimportable_module():

--- a/tests/test_sage_worker.py
+++ b/tests/test_sage_worker.py
@@ -731,6 +731,92 @@ def test_guarded_attrcall_screens_the_attribute_name(monkeypatch):
             _sage_worker._guarded_attrcall(forbidden)
 
 
+def test_set_verbose_is_offered_as_a_noop(monkeypatch):
+    """`set_verbose(2)` opens many doctests as setup noise. It only sets a global
+    chattiness level with no surface over MCP, so it is offered as a no-op rather
+    than refused -- the validator accepts it and the namespace runs it (item 64).
+    """
+    from sagemath_mcp import _sage_worker
+
+    monkeypatch.setattr(_sage_worker, "PURE_PYTHON", True)
+    ns = _sage_worker._build_namespace()
+    result = _sage_worker._execute(
+        "set_verbose(2)", want_latex=False, capture_stdout=False,
+        namespace=ns, trusted=False,
+    )
+    assert result["ok"] is True
+    assert result.get("result") is None  # a no-op returns nothing
+
+
+def test_caller_shims_survive_a_reseal(monkeypatch):
+    """Before item 64 the scrub removed `attrcall` and nothing put it back, so it
+    worked at startup and vanished after the first specialised-tool call (which
+    reseals). The shims are reinstalled after every scrub; `set_verbose` stays
+    offered, `attrcall` stays withheld (screened-call-only)."""
+    from sagemath_mcp import _sage_worker
+
+    monkeypatch.setattr(_sage_worker, "PURE_PYTHON", True)
+    ns = _sage_worker._build_namespace()
+    assert "attrcall" in ns and "set_verbose" in ns
+
+    _sage_worker._reseal_namespace(ns)
+    assert "attrcall" in ns and "set_verbose" in ns
+    assert "set_verbose" not in _sage_worker._WITHHELD_NAMES
+    assert "attrcall" in _sage_worker._WITHHELD_NAMES
+
+
+def test_symbol_shaped_free_names_pass_validation(monkeypatch):
+    """evaluate_sage declares a symbol-shaped free name instead of refusing it,
+    so validation accepts `w` and reports it as auto-declared (item 65)."""
+    from sagemath_mcp import _sage_worker
+
+    monkeypatch.setattr(_sage_worker, "PURE_PYTHON", True)
+    compiled = _sage_worker._split_code("w + 1")
+    assert "w" in compiled.auto_symbols
+    # A multi-letter name is not symbol-shaped: a typo stays an error.
+    with pytest.raises(SecurityViolation):
+        _sage_worker._split_code("sinn(x)")
+
+
+def test_symbol_auto_declaration_does_not_shadow_a_session_variable(monkeypatch):
+    """A name the caller already assigned is offered as their value, not turned
+    into a fresh symbol -- so `w` stays whatever the session set it to."""
+    from sagemath_mcp import _sage_worker
+
+    monkeypatch.setattr(_sage_worker, "PURE_PYTHON", True)
+    monkeypatch.setattr(_sage_worker, "_CALLER_BOUND_NAMES", {"w"})
+    compiled = _sage_worker._split_code(
+        "w + 1", session_names=_sage_worker._CALLER_BOUND_NAMES
+    )
+    assert "w" not in compiled.auto_symbols
+
+
+def test_symbol_auto_declaration_computes_and_respects_session():
+    """End to end on real Sage: an undeclared `w` becomes a symbol and computes;
+    a `w` the session already set to a number stays that number (item 65)."""
+    pytest.importorskip("sage.all")
+    from sagemath_mcp import _sage_worker
+
+    ns = _sage_worker._build_namespace()
+    ok = _sage_worker._execute(
+        "expand((w + 1)^2)", want_latex=False, capture_stdout=False,
+        namespace=ns, trusted=False,
+    )
+    assert ok["ok"] is True and ok["result"] == "w^2 + 2*w + 1"
+
+    # Now the caller pins w to a number; the next read must keep it, not resymbol.
+    _sage_worker._execute("w = 5", want_latex=False, capture_stdout=False,
+                          namespace=ns, trusted=False)
+    pinned = _sage_worker._execute("w + 1", want_latex=False, capture_stdout=False,
+                                   namespace=ns, trusted=False)
+    assert pinned["ok"] is True and pinned["result"] == "6"
+
+    # A multi-letter typo is still refused, not silently turned into a symbol.
+    typo = _sage_worker._execute("sinn(x)", want_latex=False, capture_stdout=False,
+                                 namespace=_sage_worker._build_namespace(), trusted=False)
+    assert typo["ok"] is False
+
+
 def test_guarded_attrcall_delegates_to_sage_when_available(monkeypatch):
     import sys
     import types

--- a/tests/test_security_bypass.py
+++ b/tests/test_security_bypass.py
@@ -852,9 +852,10 @@ def test_no_module_object_exposes_a_getattr_primitive() -> None:
 
 
 def test_a_star_import_cannot_hand_a_caller_a_module_object() -> None:
-    """Item 61. The curated `import *` feature (item 60) admitted two modules
-    that re-export a module object -- `sage.modular.dims` exports `dirichlet`
-    (the `sage.modular.dirichlet` module) and `real_roots` exports `time`.
+    """Items 61 and 63. The curated `import *` feature (item 60) admitted two
+    modules that re-export a module object -- `sage.modular.dims` exports
+    `dirichlet` (the `sage.modular.dirichlet` module) and `real_roots` exports
+    `time`.
 
     A bound module object is a pivot: `dirichlet.free_module_element.sage.env.os`
     reached the real `os` module, the validator's terminal-segment rule treated
@@ -863,8 +864,11 @@ def test_a_star_import_cannot_hand_a_caller_a_module_object() -> None:
     Confirmed to escape before the fix -- the snippet returned ok and os.system
     wrote a file owned by uid 1001.
 
-    The screen now rejects any module-object export by type, so no curated
-    module can hand a caller a module, and the two offending modules drop out.
+    Item 63 keeps the guarantee while restoring the mathematics: the module
+    object is DROPPED from the screened names rather than failing the module, so
+    `dims` is star-exportable again but `dirichlet` is not among the names it
+    binds. The invariant asserted here is unchanged -- no caller ever binds a
+    module object -- only the mechanism is.
     """
     pytest.importorskip("sage.all")
     import types
@@ -882,12 +886,15 @@ def test_a_star_import_cannot_hand_a_caller_a_module_object() -> None:
                 f"can pivot through it to os/sys/subprocess"
             )
 
-    # The concrete module that caused the escape no longer screens clean, so it
-    # is not in the list and its star import is refused like any other.
-    assert _sage_worker._star_export_screen("sage.modular.dims") is None
-    assert "sage.modular.dims" not in STAR_EXPORTS
+    # `dims` is admitted again, but the module object `dirichlet` was dropped
+    # from what it binds -- present in the module, absent from the star.
+    screened = _sage_worker._star_export_screen("sage.modular.dims")
+    assert screened is not None and "dirichlet" not in screened
+    assert "sage.modular.dims" in STAR_EXPORTS
+    assert "dirichlet" not in STAR_EXPORTS["sage.modular.dims"]
 
-    # End to end: the exact reproducer is refused rather than reaching `os`.
+    # End to end: the reproducer is still refused, because the star import does
+    # not bind `dirichlet` and the validator refuses the unoffered name.
     namespace = _sage_worker._build_namespace()
     reproducer = (
         "from sage.modular.dims import *\n"
@@ -899,6 +906,28 @@ def test_a_star_import_cannot_hand_a_caller_a_module_object() -> None:
         namespace=namespace, trusted=False,
     )
     assert result["ok"] is False
+
+
+def test_a_module_dropped_star_import_still_computes() -> None:
+    """Item 63's point: dropping the module object keeps the mathematics. The
+    star import binds the real functions and runs, while the dropped module
+    object stays unreachable."""
+    pytest.importorskip("sage.all")
+    from sagemath_mcp import _sage_worker
+
+    namespace = _sage_worker._build_namespace()
+    ok = _sage_worker._execute(
+        "from sage.modular.dims import *\ndimension_cusp_forms(Gamma0(11), 2)",
+        want_latex=False, capture_stdout=False, namespace=namespace, trusted=False,
+    )
+    assert ok["ok"] is True and ok["result"] == "1"
+
+    # The dropped module object is not bound by the star import.
+    refused = _sage_worker._execute(
+        "from sage.modular.dims import *\ndirichlet",
+        want_latex=False, capture_stdout=False, namespace=namespace, trusted=False,
+    )
+    assert refused["ok"] is False
 
 
 # A terminal pure-module name (os, sys, ...) reached through a caller-bound root


### PR DESCRIPTION
Stacked on #43 (item 62). Three safe levers that lower how often the guardrails refuse legitimate SageMath mathematics, chosen from a measured analysis of the doctest-corpus refusals. None touches the sandbox boundary.

**Measured, real corpus sweep:** refusals **4,493 → 3,936 (−557)**, in-scope acceptance **98.80% → 98.9488%** (floor 98.50%). All 7 corpus assertions green; host suite 902 passed; full container suite 1054 passed.

## Item 63 — drop module-object star exports instead of failing the module (+278)
Item 61 failed a whole curated `import *` module when any export was a module object, costing the mathematics in `real_roots`, `dims` and the `pbori` Boolean-polynomial modules for a single `time`/`operator`/`sage`. The screen now **drops** the module-object name (before the name screens, so a re-export named `operator`/`sage` is dropped too) and keeps the rest. Safe because a module is the only *pivot* category, the expansion binds only the explicit screened names (a dropped name is never imported), and item 62 refuses the pivot at the validator even if one were. This is a deliberate, reviewed relaxation of "clean as a whole, never a filtered subset" → "…except module-object names are dropped." `ecl` stays excluded by curation (EclObject evaluates Lisp), not the screen.

## Item 64 — offer `set_verbose` as a no-op (+57)
It only sets a global chattiness level, which has no surface over MCP. Offered via a small `_CALLER_SHIMS` map reinstalled after every scrub — which also fixes a latent bug: `attrcall` was stripped by the reseal and never put back, so it silently stopped working after the first specialised-tool call.

## Item 65 — auto-declare symbol-shaped names in `evaluate_sage` (+213)
`evaluate_sage` refused undeclared symbol-shaped names (`w`, `x_2`, `alpha`) and pointed at `var()`; the specialised tools already declare them the way SR does. Now `evaluate_sage` declares them too — narrow and typo-guarded (multi-letter names stay errors), session variables are never resymboled, and a called name with a native equivalent (`r(...)` → R) keeps its redirect. The corpus sweep models this as it already models `_`, star-exports and injection.

## Tests
Each item ships unit (host) + real-Sage tests; `doctest-corpus-stats.md` (now tracked) is regenerated and shows the recovered buckets — `is not defined` goes to zero, `not-a-name` −287, `ext-program` −57. Security invariants unchanged: `test_a_star_import_cannot_hand_a_caller_a_module_object` still passes (no caller binds a module), item 62's terminal-name rule still refuses the pivot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)