### PR TITLE
Release 0.6.1 (security patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-16
+
+A security patch on 0.6.0. It closes a critical sandbox escape introduced by the
+curated `import *` feature, hardens the validator against the same class, stops a
+cross-client information leak in the monitoring resource, and — safely — reduces
+how often the guardrails refuse legitimate SageMath mathematics (doctest-corpus
+acceptance 98.69% → 98.95%).
+
+### Security
+
+- **Curated `import *` allowed arbitrary command execution (critical).** The
+  screen that vets an internal module for `from <module> import *` decided
+  provenance from each value's `__module__`, but a module object has none, so a
+  re-exported module passed — `sage.modular.dims` exports `dirichlet`. A bound
+  module object is a pivot into the whole `sage.*` tree, and the validator's
+  terminal-attribute rule then treated `alias.os` under a caller-bound root as a
+  benign method, so
+  `from sage.modular.dims import *; dirichlet.free_module_element.sage.env.os.system('id')`
+  ran a shell as the container user. The screen now drops module-object exports
+  and the validator refuses a terminal module name under any root; both are
+  covered by regression tests that fail against the unpatched code. (review
+  items 61, 62, 63)
+- **The monitoring resource leaked another client's inputs and outputs.** The
+  `resource://sagemath/monitoring/{scope}` snapshot carried the last failing
+  evaluation's error message, rejected code and untruncated stdout, and
+  `_METRICS` is a process-global singleton, so any client could read another
+  client's data over the shipped HTTP deployment. Those free-text fields are
+  dropped before the snapshot leaves the process; only non-identifying aggregate
+  counters remain. (review item 58)
+
+### Added
+
+- Caller code may now `from <module> import *` for a curated set of internal
+  SageMath modules whose public names are all ordinary mathematics, screened
+  clean as a whole and generated into `star_exports.py`. Nothing is added to the
+  allowlist. (review items 60, 63)
+- `evaluate_sage` auto-declares symbol-shaped free names (`w`, `x_2`, `alpha`)
+  as symbols, matching SageMath's SR and the specialised tools, instead of
+  refusing them. Narrow and typo-guarded: multi-letter names stay errors, and a
+  session variable is never turned back into a symbol. (review item 65)
+
+### Changed
+
+- `set_verbose` is offered to caller code as a no-op — it only sets a global
+  verbosity level, which has no surface over MCP — rather than refused. (review
+  item 64)
+- `inject_shorthands` is simulated so the names it creates are readable in the
+  session, and a literal `attrcall('method')` is accepted once its name is
+  screened against the same rules the dotted spelling would face. (review item 59)
+- `doctest-corpus-stats.md` is tracked in the repository (counts only, never
+  corpus text) so a guardrail change's effect on the acceptance rate is visible
+  in review.
+
+### Fixed
+
+- The guarded `attrcall` wrapper was stripped by the namespace reseal and never
+  reinstalled, so `attrcall` silently stopped working after the first
+  specialised-tool call in a session. Caller shims are now reinstalled after
+  every reseal. (review item 64)
+
 ## [0.6.0] - 2026-08-15
 
 A security and correctness release, and a large one. `evaluate_sage` now

--- a/charts/sagemath-mcp/Chart.yaml
+++ b/charts/sagemath-mcp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sagemath-mcp
 description: A Helm chart for deploying the SageMath MCP server.
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.6.1
+appVersion: "0.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sagemath-mcp"
-version = "0.6.0"
+version = "0.6.1"
 description = "Model Context Protocol server that provides stateful SageMath computations."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/security-review/findings.json
+++ b/security-review/findings.json
@@ -1,0 +1,64 @@
+{
+  "repo": "sagemath-mcp",
+  "commit": "0176c7e9917a3d3bc6502be4303fef4e426eb1b9",
+  "reviewed_at": "2026-08-16",
+  "scope": "pending changes on branch fix/fragment-gate-and-monitoring-leak vs main (items 55-60 + monitoring leak fix)",
+  "findings": [
+    {
+      "id": "F-001",
+      "title": "Sandbox escape via curated star-import module objects (arbitrary command execution)",
+      "severity": "Critical",
+      "confidence": "Confirmed",
+      "cwe": "CWE-94",
+      "owasp": "A03:2021",
+      "file": "src/sagemath_mcp/_sage_worker.py",
+      "line": 462,
+      "entry_point": "evaluate_sage MCP tool (untrusted caller code path)",
+      "data_flow": [
+        "caller code -> SageSession.evaluate() -> worker _execute (untrusted) -> _split_code",
+        "rewrite_permitted_imports expands 'from sage.modular.dims import *' to explicit names incl. dirichlet (a module object)",
+        "_star_export_screen admitted dirichlet because module objects have no __module__, so the provenance check at line 462 returns '' and passes",
+        "validate_module approves 'alias = dirichlet.free_module_element.sage.env.os' because the terminal-segment rule (security.py:1238-1242) treats a forbidden parent 'os' under a non-allowlisted root as a benign method",
+        "alias is the real os module; alias.system('...') is unguarded (system removed from forbidden_attribute_names)"
+      ],
+      "impact": "Verified live on SageMath 10.9: os.system executed and wrote /tmp/PWNED2 with uid=1001(sage); os.environ and os.getcwd readable. RCE on host in the default stdio (no-container) deployment; env/secret disclosure + outbound sockets even in the hardened container deployment.",
+      "remediation": "In _star_export_screen reject any export whose value is a types.ModuleType (drops sage.modular.dims and sage.rings.polynomial.real_roots), regenerate star_exports.py, and add a regression test running the reproducer through the untrusted path. Defence-in-depth: in security.py:1238 do not treat a forbidden parent as a benign terminal method when the chain root is a caller-bound import alias.",
+      "compliance": [],
+      "effort": "Trivial",
+      "verdict": "CONFIRMED",
+      "regression_introduced_by_branch": true
+    }
+  ],
+  "rejected": [
+    {
+      "title": "attrcall literal screening bypass",
+      "reason": "Probed save/eval/dunder/write/bare-alias/non-literal forms; all refused. Benign literals pass and the runtime _guarded_attrcall re-screens with the same function."
+    },
+    {
+      "title": "Token-screen (item 55) scrubbed-name rescue via generator target",
+      "reason": "Rescued scrubbed names are removed from sage.all, so naming them yields NameError; always_forbidden (call names + attr parents) is not overridden by the rescue."
+    },
+    {
+      "title": "Monitoring resource cross-client leak (post-fix)",
+      "reason": "public_snapshot() pops the three free-text fields and MonitoringSnapshot no longer declares them; only process-wide aggregates reach the wire."
+    }
+  ],
+  "coverage": {
+    "reviewed": [
+      "full branch source diff",
+      "src/sagemath_mcp/security.py",
+      "src/sagemath_mcp/codegen.py",
+      "src/sagemath_mcp/_sage_worker.py",
+      "src/sagemath_mcp/star_exports.py",
+      "src/sagemath_mcp/monitoring.py",
+      "src/sagemath_mcp/models.py",
+      "src/sagemath_mcp/tools/session.py",
+      "scripts/generate_star_exports.py"
+    ],
+    "not_reviewed": [
+      "capability (not name/provenance) of every callable in the 13 curated star modules",
+      "the pre-existing validator beyond lines this branch touches"
+    ],
+    "limitations": "The star-export screen is capability-blind by design (see sage.libs.ecl / EclObject note in the generator). Sage-backed tests and reproducers executed in the running sage-mcp container on SageMath 10.9; no source modified during review."
+  }
+}

--- a/security-review/report.md
+++ b/security-review/report.md
@@ -1,0 +1,162 @@
+# Security review — branch `fix/fragment-gate-and-monitoring-leak`
+
+**Scope:** the pending changes on this branch versus `main` (commits `4854cab..0176c7e`,
+review items 55–60 plus the monitoring leak fix). Reviewed at commit
+`0176c7e9917a3d3bc6502be4303fef4e426eb1b9`.
+
+**Method:** read the full source diff; ran the pure-Python suite (886 passed) and the
+Sage-backed security/integration/coverage suites inside the running `sage-mcp`
+container (426 passed); then wrote adversarial probes against the three new attack
+surfaces (star-import expansion, `attrcall` literal screening, `inject_shorthands`)
+and executed them end-to-end through the real worker on SageMath 10.9.
+
+**Headline:** one **Critical** — the new star-import feature (item 60) is a complete
+bypass of the AST validator and yields arbitrary command execution through the
+`evaluate_sage` tool. Verified live: `os.system` ran and wrote a file as the container
+user. The other four changes (monitoring redaction, `attrcall` screening, the token-screen
+rework, `inject_shorthands`) reviewed clean.
+
+---
+
+## [Critical · Confirmed] — Sandbox escape via curated star-import module objects (CWE-94 / CWE-913 / OWASP A03:2021)
+
+**Location:**
+- `src/sagemath_mcp/_sage_worker.py:462` — `_star_export_screen()`, the provenance check
+- `src/sagemath_mcp/star_exports.py:82` (`sage.modular.dims`) and `:29`
+  (`sage.rings.polynomial.real_roots`) — the two admitted modules that export a module object
+- `src/sagemath_mcp/security.py:1238-1242` — the terminal-segment attribute rule that the
+  pivot exploits
+
+**Reachable from:** the `evaluate_sage` (and `evaluate_sage_streaming`) MCP tool — the
+primary entry point. Caller code → `SageSession.evaluate()` → worker `_execute` (untrusted
+path) → `_split_code` → `rewrite_permitted_imports` expands the star → `validate_module`
+approves → `exec` in the persistent namespace.
+
+**Description.** Item 60 permits `from <curated module> import *` for 13 internal Sage
+modules whose public names `_star_export_screen` judged "clean as a whole." The screen
+decides a value's provenance with `home = getattr(value, "__module__", "")`
+(`_sage_worker.py:462`). **Module objects have no `__module__`** (they carry `__name__`), so
+`home` is `""` and every re-exported module object passes the screen silently. Two of the 13
+curated modules re-export module objects:
+
+- `sage.modular.dims` exports `dirichlet` = the module `sage.modular.dirichlet`
+- `sage.rings.polynomial.real_roots` exports `time` = the stdlib `time` module
+
+A bound Sage module object is a pivot into the entire `sage.*` tree. `sage.modular.dirichlet`
+re-exports `sage.modules.free_module_element`, which reaches `sage` → `sage.env` → `os`,
+`sys`, `subprocess`, `socket`, `shutil` (all imported by ordinary Sage submodules).
+
+The second half of the chain is the terminal-segment rule at `security.py:1238`. For an
+attribute chain `X.os` whose **root is caller-bound and not on the allowlist**, the validator
+computes `module_path = root in allowed_names` (False here) and then `if not module_path …:
+continue` — i.e. it treats the terminal `os` as a harmless *method name* on a mathematical
+object, not as the `os` module. That inference is correct for `A.trace()` but false when the
+root is a module object: `dirichlet.free_module_element.sage.env.os` **is** the real `os`
+module, and the whole chain contains no forbidden *parent* before the terminal `os`, so
+nothing fires. The caller binds `os` to a fresh name and calls `.system()` — which was
+deliberately removed from `forbidden_attribute_names`, so `alias.system('…')` is unguarded.
+
+**Impact — verified, not theoretical.** A single `evaluate_sage` call:
+
+```python
+from sage.modular.dims import *
+_m = dirichlet.free_module_element.sage.env.os
+_m.system('id > /tmp/PWNED2 2>&1')
+```
+
+executed on SageMath 10.9 in the container: the snippet returned `ok`, and `/tmp/PWNED2`
+contained `uid=1001(sage) gid=1001(sage) groups=1001(sage)`. `_m.environ['PATH']` and
+`_m.getcwd()` also returned live values, so the same alias reads every environment variable
+(secrets injected via compose env land here) and opens outbound sockets.
+
+Blast radius depends on deployment:
+- **stdio (the default, Claude Desktop / `uv run sagemath-mcp`)** runs with **no container**.
+  There the AST validator is the only boundary, so this is arbitrary code execution on the
+  user's host.
+- **Docker/Helm** are hardened (`read_only`, `cap_drop: ALL`, `no-new-privileges`,
+  non-root). The escape is bounded to: read all env vars, read the mounted checkout, write
+  the `/tmp` and `/home/sage/.sage` tmpfs, and open outbound network connections (compose
+  does not set `network_mode: none`). That is still full environment/secret disclosure and
+  an exfil channel.
+
+The project's own model ("the validator is defence in depth, the container is the boundary")
+holds only where a container exists; the default deployment has none.
+
+**Controls checked and ruled out.**
+- Namespace scrub (`_strip_from_sage_all`) removes names from `sage.all` only, never from
+  `sage.modular.dirichlet.__dict__` or `sage.env.__dict__`, so the pivot modules are intact.
+- `forbidden_attribute_parents` catches `os`/`sys`/… only *mid-chain*; as the terminal
+  segment under a non-allowlisted root they are skipped (the rule at `security.py:1242`).
+- `forbidden_attribute_names` no longer contains `system` (removed in an earlier item as
+  "redundant, since `os` is unreachable" — a premise this feature invalidates).
+- Dunder rule does not apply — no `__…__` is used.
+- The drift test `test_the_star_exports_match_this_sage` **passes**: it re-runs the same
+  blind screen, so it agrees the modules are "clean." It does not protect against this class.
+
+**Remediation.** Close it in the screen (the root cause); either fix drops both offending
+modules from `STAR_EXPORTS` under the "clean as a whole" rule:
+
+1. In `_star_export_screen` (`_sage_worker.py`), reject any export whose value is a module:
+   ```python
+   import types
+   ...
+   value = vars(module).get(name)
+   if isinstance(value, types.ModuleType):
+       return None          # a bound module object is a pivot into sage.*/stdlib
+   ```
+   This is decisive and cheap. Regenerate `star_exports.py` (`make` target / the generator)
+   and confirm `sage.modular.dims` and `sage.rings.polynomial.real_roots` drop out.
+
+2. Defence in depth, independently worth doing: in the terminal-segment rule
+   (`security.py:1238`) do **not** treat a forbidden parent as a benign method when the root
+   is a caller-bound *import alias*. `_split_code` already knows which bound names came from
+   an `ast.alias`; a chain rooted at an imported name should be judged a module path
+   regardless of allowlist membership.
+
+Add a regression test that runs the verified reproducer above through the untrusted worker
+path and asserts it is refused. Note the screen is inherently capability-blind (the generator
+comment already flags `sage.libs.ecl`/`EclObject`), so the module-object check hardens one
+known class; the residual risk below still argues for keeping the curated list minimal.
+
+**References:** CWE-94 (code injection), CWE-913 (improper control of dynamically-managed
+code resources), OWASP A03:2021 (Injection).
+
+---
+
+## Residual risk (not a discrete finding) — the star-export screen is capability-blind
+
+`_star_export_screen` is a name + provenance filter. It cannot see what a *callable* does:
+the generator already excludes `sage.libs.ecl` by hand because `EclObject` evaluates Lisp,
+which no name check detects. The module-object fix above closes the one confirmed hole, but
+every added module still rests on human judgement that none of its exported callables
+exec/compile/open/connect internally. Keep `CANDIDATE_MODULES` as small as the corpus
+genuinely needs, and treat each addition as a manual capability review, not a screen pass.
+
+---
+
+## Changes reviewed and cleared
+
+- **Monitoring leak fix (item 58)** — `MonitoringSnapshot` drops the three free-text fields
+  and `public_snapshot()` pops them before serialisation; the resource emits only
+  process-wide aggregates. `snapshot()` still returns the fields for server logs. Sound; the
+  sibling `session_resource` correctly scopes by `ctx.session_id` and fails closed.
+- **`attrcall` literal screening (item 59)** — verified `attrcall('save'…)`, `('eval')`,
+  `('__reduce__')`, `('write_to_eps')`, a bare alias, and a non-literal argument are all
+  refused; benign literals like `attrcall('bruhat_le')` pass, and the runtime
+  `_guarded_attrcall` re-screens with the same function, so static/runtime cannot drift.
+- **Token-screen rework (item 55)** — the attribute-vs-bare split via a preceding `.` token
+  mirrors the AST path; scrubbed names are removed from `sage.all` so the `bound` rescue is
+  safe. Correctly stops over-rejecting `save_point`/`dump_total` while still blocking
+  `obj.save_image`.
+- **`inject_shorthands` + `__name__="__main__"` (item 59)** — injected names are ordinary
+  mathematical shorthands; the namespace diff that trusts them is gated on the caller having
+  written the injecting call, and scrubbed names cannot be injected.
+
+## Coverage / limitations
+
+Reviewed: the full branch source diff and all changed `src/` modules. Executed the
+Sage-backed security suite and my own reproducers on SageMath 10.9 in the `sage-mcp`
+container. Not independently re-audited: the unchanged pre-existing validator beyond the
+lines this branch touches, and the capability of every individual callable in the 13 curated
+star modules (screened by name/provenance only — see residual risk). No source files were
+modified during this review.

--- a/security-review/summary.md
+++ b/security-review/summary.md
@@ -1,0 +1,50 @@
+# Security review summary — branch `fix/fragment-gate-and-monitoring-leak`
+
+**Reviewed:** the pending changes on this branch (items 55–60 + the monitoring leak fix)
+against `main`, at commit `0176c7e`. Findings verified live against SageMath 10.9 in the
+`sage-mcp` container.
+
+## Findings by severity
+
+| Severity | Count |
+|----------|-------|
+| Critical | 1 |
+| High / Medium / Low | 0 |
+
+## Needs action this week
+
+1. **F-001 (Critical) — Fix the star-import escape before this branch merges.** The new
+   item-60 feature lets a single `evaluate_sage` call reach the real `os` module and run
+   shell commands (`os.system` confirmed executing as uid 1001; `os.environ` readable). Two
+   of the 13 curated modules re-export module objects (`dirichlet`, `time`) that the
+   `_star_export_screen` provenance check cannot see, because module objects have no
+   `__module__`. The one-line fix is to reject `types.ModuleType` exports in the screen and
+   regenerate `star_exports.py`; add a regression test using the verified reproducer. This
+   is a regression introduced by this branch — the feature does not exist on `main`.
+
+## Systemic pattern (one root cause, not one ticket)
+
+The escape is the intersection of two design assumptions that were each individually
+reasonable and became false together:
+
+- **The star-export screen trusts name + provenance, not capability.** The generator already
+  concedes this (it hand-excludes `sage.libs.ecl` because `EclObject` evaluates Lisp). The
+  module-object hole is the same shape: a value the screen approves whose *behaviour* it
+  never examined. Keep `CANDIDATE_MODULES` minimal and treat each addition as a manual
+  capability review.
+- **The validator treats `X.os` under a non-allowlisted root as a benign method access.**
+  True for a mathematical object, false for a module object. Any feature that lets caller
+  code bind a module object to a name reopens the whole `os`/`sys`/`subprocess` surface. The
+  attribute rule should refuse a forbidden parent as terminal whenever the root is a
+  caller-bound import alias.
+
+## Coverage and confidence
+
+**High confidence, focused scope.** I read the entire branch diff, ran the pure-Python suite
+(886 passed) and the Sage-backed security/integration/coverage suites (426 passed), and
+executed my own adversarial reproducers end-to-end through the real worker. The other four
+changes — the monitoring redaction, `attrcall` literal screening, the token-screen rework,
+and `inject_shorthands` — were each probed and cleared. The residual, un-eliminated risk is
+the capability-blindness of the star-export screen: the fix closes the confirmed
+module-object class, but the curated list still rests on human judgement for every callable
+it admits. No source files were modified during this review (`git status` clean).

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.XBP-Europe/sagemath-mcp",
   "title": "SageMath",
   "description": "Stateful SageMath MCP server with 33 symbolic math tools and a sandboxed Sage session per client.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "websiteUrl": "https://github.com/XBP-Europe/sagemath-mcp",
   "repository": {
     "url": "https://github.com/XBP-Europe/sagemath-mcp",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "sagemath-mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/sagemath_mcp/__init__.py
+++ b/src/sagemath_mcp/__init__.py
@@ -5,5 +5,5 @@ from importlib.metadata import PackageNotFoundError, version
 try:  # pragma: no cover - executed during packaging only
     __version__ = version("sagemath-mcp")
 except PackageNotFoundError:  # pragma: no cover - local dev fallback
-    __version__ = "0.6.0"
+    __version__ = "0.6.1"
 __all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -1674,7 +1674,7 @@ wheels = [
 
 [[package]]
 name = "sagemath-mcp"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Prepares the **0.6.1 security release** — a patch on 0.6.0 with the current code, all of it (review items 58–65).

Bumps the version across `pyproject.toml`, `__init__.py`, `charts/.../Chart.yaml`, `server.json` and `uv.lock`, and adds the 0.6.1 changelog entry.

## What 0.6.1 ships

**Security**
- **Critical sandbox escape in the curated `import *` feature.** A re-exported module object (`sage.modular.dims` → `dirichlet`) passed the screen and was a pivot to the real `os` module; `...dirichlet.free_module_element.sage.env.os.system('id')` ran a shell. The screen now drops module-object exports and the validator refuses a terminal module name under any root. (items 61, 62, 63)
- **Monitoring resource cross-client leak** — free-text error/rejected-code/stdout fields removed from the process-global snapshot. (item 58)

**Added / Changed / Fixed**
- Curated `from <module> import *` for clean internal modules (items 60, 63); `evaluate_sage` symbol auto-declaration (item 65); `set_verbose` no-op (item 64); `inject_shorthands` simulation + `attrcall` literal screening (item 59); `attrcall`-survives-reseal fix (item 64). Doctest-corpus acceptance 98.69% → 98.95%.

## Verification
Version files agree (`test_version_consistency`), host suite 904 passed, lint clean, `uv lock --check` resolves, changelog note-extraction verified. After merge, tag `v0.6.1` triggers the release workflow (PyPI + signed GHCR image + MCP registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)