### PR TITLE
Add glama.json to claim the Glama listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["csteinlxbp"]
+}


### PR DESCRIPTION
Glama auto-indexed this server at https://glama.ai/mcp/servers/XBP-Europe/sagemath-mcp. Claiming a listing whose repository is owned by an organization requires a `glama.json` at the repository root naming the maintainers ([Glama docs](https://glama.ai/blog/2025-07-08-what-is-glamajson)) — personal GitHub auth only works for personal repositories.

After merging, the remaining manual step is to run the **Claim ownership** flow on the listing page while logged in.

Closes the Glama item in TODO.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135Z8yq1oSbz1WkPXAEKuhb