### PR TITLE
Keep the caller shims out of the generated allowlist

### DIFF
--- a/scripts/generate_allowlist.py
+++ b/scripts/generate_allowlist.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import math
 import textwrap
 
-from sagemath_mcp._sage_worker import _build_namespace, _restricted_builtins
+from sagemath_mcp._sage_worker import _CALLER_SHIMS, _build_namespace, _restricted_builtins
 
 HEADER = '''"""The names caller code is allowed to read.
 
@@ -66,6 +66,12 @@ def main() -> int:
     # so log10, comb and friends are legitimate names there. Including them keeps
     # one allowlist valid for both runtimes; they are ordinary maths either way.
     names |= {name for name in vars(math) if not name.startswith("_")}
+    # The caller shims sit in the namespace (installed after the scrub), but they
+    # are deliberately not baked in here: `attrcall` is refused bare and permitted
+    # only as a screened literal call, and `set_verbose` is offered per-evaluation
+    # through `_OFFERED_SHIM_NAMES` so its baked refusal can name the streaming
+    # tool. Three tests fail when either one lands in the allowlist.
+    names -= set(_CALLER_SHIMS)
     body = textwrap.fill(
         ", ".join(f'"{name}"' for name in sorted(names)),
         width=88,


### PR DESCRIPTION
Found while regenerating against SageMath 10.10.beta9, but latent on every version: `generate_allowlist.py` emits every name in `_build_namespace()`, and the caller shims moved inside that function when they began surviving reseals — so any regeneration now bakes `attrcall` and `set_verbose` into the allowlist. Both are deliberately absent from it (`attrcall` is refused bare and permitted only as a screened literal call; `set_verbose` is offered per-evaluation via `_OFFERED_SHIM_NAMES` so its baked refusal can name the streaming tool), and three tests trip when either lands there.

The fix subtracts `_CALLER_SHIMS` in the generator. No allowlist change on main: the committed file already lacks both names, this just makes regeneration reproduce it.

Companion: #51-adjacent beta branch `beta/sage-10.10` carries this same commit plus the 10.10.beta9 retarget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135Z8yq1oSbz1WkPXAEKuhb