### PR TITLE
Cover sympy-mcp's showcase as a use case, GR included

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -127,6 +127,29 @@ Interrupting is not cancelling. `interrupt_sage_session` abandons the running
 computation and keeps every variable; `cancel_sage_session` restarts the worker
 and discards them. Prefer the first.
 
+### Worked example: general relativity through `evaluate_sage`
+
+There is no dedicated tensor tool — deliberately, see ROADMAP.md — because the
+whole SageManifolds workflow passes the policy as ordinary `evaluate_sage`
+calls, including the preparser-only chart syntax. Curvature of the hyperbolic
+plane (the 2D Anti-de Sitter analogue), one call:
+
+```python
+H = Manifold(2, 'H', structure='Riemannian')
+X.<p,q> = H.chart('p q:(0,+oo)')
+g = H.metric('g')
+g[0,0] = 1/q^2
+g[1,1] = 1/q^2
+g.ricci_scalar().expr()   # -> -2, constant negative curvature
+```
+
+Lorentzian signatures (`structure='Lorentzian'`), the metric catalog
+(`manifolds.Sphere(2).induced_metric()`), Ricci and Riemann tensors and
+connections all work the same way; the session keeps the manifold alive across
+calls, so the metric can be defined once and interrogated repeatedly.
+`tests/test_use_cases.py::test_use_cases_cover_the_sympy_mcp_showcase` pins
+this workflow against a real Sage runtime.
+
 ## Verifying the Server
 ### Automated Tests & Lint
 ```bash

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -75,3 +75,128 @@ async def test_use_cases_cover_manual_examples(monkeypatch):
     finally:
         await manager.shutdown()
         runtime.SESSION_MANAGER = original_manager
+
+
+@requires_sage
+@pytest.mark.asyncio
+async def test_use_cases_cover_the_sympy_mcp_showcase(monkeypatch):
+    """sympy-mcp's own examples and test cases, translated to this server.
+
+    sympy-mcp -- the most-starred symbolic MCP server -- demonstrates itself
+    with a fixed set of workloads: polynomial and trigonometric derivatives,
+    matrix determinants and eigenvalues, substitution, the damped harmonic
+    oscillator, a coupled two-tank ODE system checked against its algebraic
+    steady state, general relativity through predefined and custom metrics, and
+    unit conversion (its tests/ and README, surveyed 2026-08-24). Every one is
+    reachable here through `evaluate_sage` alone, in a single session whose
+    state carries across calls -- no expression handles -- which is the
+    architectural claim this test pins.
+
+    The relativity cases double as the manifolds coverage the roadmap's
+    field-survey item calls for: `Manifold` and the `manifolds` catalog are
+    allowlisted, and this asserts the policy accepts the whole curvature
+    workflow, not merely the names. Deliberately absent: sympy-mcp's LaTeX
+    assertions, because `latex` is withheld here by design -- results come
+    back as text.
+    """
+    original_manager = runtime.SESSION_MANAGER
+    settings = SageSettings()
+    manager = SageSessionManager(settings)
+    monkeypatch.setattr(runtime, "SESSION_MANAGER", manager)
+
+    ctx = FakeContext("sympy-mcp-showcase")
+
+    try:
+        # test_calculus: first, second and third derivative of x^3.
+        derivs = await server.evaluate_sage(
+            "x = var('x')\n[diff(x^3, x, k) for k in (1, 2, 3)]",
+            ctx=ctx,
+        )
+        assert derivs.result == "[3*x^2, 6*x, 6]"
+
+        # test_linalg: determinant and eigenvalues of its fixture matrices.
+        det = await server.evaluate_sage("matrix(QQ, [[1, 2], [3, 4]]).det()", ctx=ctx)
+        assert det.result == "-2"
+        eigen = await server.evaluate_sage(
+            "matrix(QQ, [[3, 1], [1, 3]]).eigenvalues()", ctx=ctx
+        )
+        assert eigen.result == "[4, 2]"
+
+        # test_linalg substitution -- `x` survives from the first call, which is
+        # the session model sympy-mcp's expression handles stand in for.
+        subs = await server.evaluate_sage(
+            "y = var('y')\n(x^2 + y^2).subs(y=y + 1)", ctx=ctx
+        )
+        assert subs.result == "x^2 + (y + 1)^2"
+
+        # README example 1: the damped harmonic oscillator (underdamped instance).
+        oscillator = await server.evaluate_sage(
+            "t = var('t')\n"
+            "xf = function('x')(t)\n"
+            "desolve(diff(xf, t, 2) + 2*diff(xf, t) + 5*xf == 0, xf, ivar=t)",
+            ctx=ctx,
+        )
+        assert "cos(2*t)" in oscillator.result
+        assert "e^(-t)" in oscillator.result
+
+        # README example 3: the coupled two-tank system. The long-term limits of
+        # the ODE solution must agree with the algebraic steady state.
+        tanks = await server.evaluate_sage(
+            "h1 = function('h1')(t)\n"
+            "h2 = function('h2')(t)\n"
+            "eqs = [diff(h1, t) == (1/2 - 3/10*(h1 - h2))/2,\n"
+            "       diff(h2, t) == (3/10*(h1 - h2) - 3/10*h2)/1]\n"
+            "sol = desolve_system(eqs, [h1, h2], ics=[0, 0, 0])\n"
+            "[limit(s.rhs(), t=oo) for s in sol]",
+            ctx=ctx,
+        )
+        assert tanks.result == "[10/3, 5/3]"
+        steady = await server.evaluate_sage(
+            "a, b = var('a b')\n"
+            "solve([1/2 - 3/10*(a - b) == 0, 3/10*(a - b) - 3/10*b == 0], a, b)",
+            ctx=ctx,
+        )
+        assert "a == (10/3)" in steady.result
+        assert "b == (5/3)" in steady.result
+
+        # test_relativity custom metric: flat 2D Lorentzian, vanishing curvature.
+        flat = await server.evaluate_sage(
+            "M = Manifold(2, 'M', structure='Lorentzian')\n"
+            "X.<u,v> = M.chart()\n"
+            "g = M.metric('g')\n"
+            "g[0,0] = -1\n"
+            "g[1,1] = 1\n"
+            "g.ricci_scalar().expr()",
+            ctx=ctx,
+        )
+        assert flat.result == "0"
+
+        # README example 2 in two dimensions: constant negative scalar curvature
+        # of the hyperbolic plane, the AdS analogue their AntiDeSitter case pins.
+        hyperbolic = await server.evaluate_sage(
+            "H = Manifold(2, 'H', structure='Riemannian')\n"
+            "XH.<p,q> = H.chart('p q:(0,+oo)')\n"
+            "gh = H.metric('gh')\n"
+            "gh[0,0] = 1/q^2\n"
+            "gh[1,1] = 1/q^2\n"
+            "gh.ricci_scalar().expr()",
+            ctx=ctx,
+        )
+        assert hyperbolic.result == "-2"
+
+        # test_relativity predefined metric: a catalog manifold's curvature.
+        sphere = await server.evaluate_sage(
+            "S = manifolds.Sphere(2)\nS.induced_metric().ricci_scalar().expr()",
+            ctx=ctx,
+        )
+        assert sphere.result == "2"
+
+        # test_units: exact conversion (their speed_of_light case is a physics
+        # constant Sage's units module does not carry; distance is the analogue).
+        miles = await server.evaluate_sage(
+            "units.length.mile.convert(units.length.kilometer)", ctx=ctx
+        )
+        assert miles.result == "25146/15625*kilometer"
+    finally:
+        await manager.shutdown()
+        runtime.SESSION_MANAGER = original_manager


### PR DESCRIPTION
Implements the "Manifolds and GR: document, don't build" roadmap item (#53) by translating sympy-mcp's entire self-demonstration — its `tests/` fixtures and all three README examples — into one integration use-case test:

- **test_calculus / test_linalg**: derivatives of `x^3`, det `-2`, eigenvalues `[4, 2]`, substitution — with `x` deliberately reused across calls to pin the session model their expression handles stand in for.
- **README ex. 1**: damped harmonic oscillator via `desolve`.
- **README ex. 3**: coupled two-tank ODE system — `desolve_system` limits `[10/3, 5/3]` must agree with the algebraic steady state.
- **test_relativity / README ex. 2**: custom flat Lorentzian metric (R = 0), hyperbolic plane (R = −2, the AdS analogue), and the `manifolds` catalog sphere (R = 2) — the first end-to-end assertion that the policy accepts the SageManifolds workflow, preparser chart syntax included.
- **test_units**: exact mile→kilometer conversion (their `speed_of_light` case is a physics constant Sage's units module doesn't carry).

Their LaTeX assertions are deliberately not carried over — `latex` is withheld by design.

USAGE.md gains the worked GR example plus the pointer to the test. Verified against real Sage: the new test passes in 5.5 s; lint and the full unit suite (904) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135Z8yq1oSbz1WkPXAEKuhb