### PR TITLE
Lead the worker's own process group and shield the protocol descriptor

### DIFF
--- a/src/sagemath_mcp/_sage_worker.py
+++ b/src/sagemath_mcp/_sage_worker.py
@@ -999,6 +999,34 @@ class _StreamingStdout(io.StringIO):
         )
 
 
+# The JSON protocol's private stream, populated by _shield_protocol_stream()
+# when running as the actual worker process. None means "not shielded" -- the
+# in-process test harness -- and the protocol falls back to sys.stdout.
+_PROTOCOL: Any = None
+
+
+def _protocol_stream() -> Any:
+    return _PROTOCOL if _PROTOCOL is not None else sys.stdout
+
+
+def _shield_protocol_stream() -> None:
+    """Move the JSON protocol off descriptor 1.
+
+    The parent reads protocol responses from the worker's descriptor 1 with
+    readline(). redirect_stdout() rebinds only Python's sys.stdout -- a child
+    process a Sage internal forks, or a C library writing to the descriptor
+    directly, still lands mid-JSON-line and desyncs every request after it.
+    So the pipe is duplicated to a private descriptor for the protocol, and
+    descriptor 1 is pointed at stderr: raw writes surface as logged worker
+    noise instead of framing corruption. Called from the entrypoint only --
+    in-process tests must not have their own descriptors rewired.
+    """
+    global _PROTOCOL
+    sys.stdout.flush()
+    _PROTOCOL = os.fdopen(os.dup(1), "w", buffering=1, encoding="utf-8")
+    os.dup2(2, 1)
+
+
 def _execute(
     code: str,
     want_latex: bool,
@@ -1019,7 +1047,7 @@ def _execute(
         }
     # stream_id turns the buffer into one that also emits line events.
     if capture_stdout and stream_id is not None:
-        stdout_buffer: io.StringIO | None = _StreamingStdout(stream_id, sys.stdout)
+        stdout_buffer: io.StringIO | None = _StreamingStdout(stream_id, _protocol_stream())
     elif capture_stdout:
         stdout_buffer = io.StringIO()
     else:
@@ -1161,6 +1189,7 @@ def _main() -> int:
                         },
                     }
                 ),
+                file=_protocol_stream(),
                 flush=True,
             )
             continue
@@ -1177,12 +1206,12 @@ def _main() -> int:
                 stream_id=msg_id if message.get("stream") else None,
             )
             response["id"] = msg_id
-            print(json.dumps(response), flush=True)
+            print(json.dumps(response), file=_protocol_stream(), flush=True)
         elif msg_type == "reset":
             namespace = _build_namespace()
-            print(json.dumps({"ok": True, "id": msg_id}), flush=True)
+            print(json.dumps({"ok": True, "id": msg_id}), file=_protocol_stream(), flush=True)
         elif msg_type == "shutdown":
-            print(json.dumps({"ok": True, "id": msg_id}), flush=True)
+            print(json.dumps({"ok": True, "id": msg_id}), file=_protocol_stream(), flush=True)
             return 0
         else:
             print(
@@ -1196,10 +1225,12 @@ def _main() -> int:
                         },
                     }
                 ),
+                file=_protocol_stream(),
                 flush=True,
             )
     return 0
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    _shield_protocol_stream()
     sys.exit(_main())

--- a/src/sagemath_mcp/session.py
+++ b/src/sagemath_mcp/session.py
@@ -155,6 +155,11 @@ class SageSession:
             # also exceed it. Sized against max_stdout, which already bounds
             # how much a result may carry.
             limit=_STREAM_LIMIT,
+            # The worker leads its own process group. Sage spawns helpers of
+            # its own -- the pexpect interfaces fork GAP and friends -- and a
+            # kill that reaches only the worker leaves those orphaned and
+            # computing. Killing the group (see _kill_worker_group) reaps them.
+            start_new_session=True,
         )
         self._stderr_task = asyncio.create_task(self._consume_stderr())
         self.started_at = time.time()
@@ -621,7 +626,7 @@ class SageSession:
         try:
             await asyncio.wait_for(self._process.wait(), timeout=self.settings.shutdown_grace)
         except TimeoutError:
-            self._process.kill()
+            self._kill_worker_group()
         self._process.stdin.close()
         with contextlib.suppress(Exception):
             await self._process.stdin.wait_closed()
@@ -664,9 +669,29 @@ class SageSession:
                 with contextlib.suppress(Exception):
                     await self._process.stdin.wait_closed()
             if self._process.returncode is None:
-                self._process.kill()
+                self._kill_worker_group()
                 await self._process.wait()
         self._process = None
+
+    def _kill_worker_group(self) -> None:
+        """SIGKILL the worker and everything it spawned.
+
+        The worker was started with ``start_new_session=True``, so its pid is
+        its process group. Killing only the worker left the children Sage forks
+        for its pexpect interfaces (GAP most visibly) alive and computing after
+        a cancel or timeout. ``interrupt`` deliberately does NOT use this: a
+        SIGINT goes to the worker alone, which forwards it to its interfaces
+        the same way the Sage REPL does.
+        """
+        assert self._process is not None
+        # AttributeError: no killpg outside POSIX. OSError: the group is
+        # already gone, or the pid was reaped and reused by another user.
+        with contextlib.suppress(AttributeError, OSError):
+            os.killpg(self._process.pid, signal.SIGKILL)
+        # Reaching the worker directly is harmless after a successful group
+        # kill and is what remains of the old behaviour everywhere else.
+        with contextlib.suppress(OSError):
+            self._process.kill()
 
 
 class SageSessionManager:

--- a/tests/test_sage_worker.py
+++ b/tests/test_sage_worker.py
@@ -1095,3 +1095,45 @@ def test_star_export_screen_rejects_a_malformed_all_entry(monkeypatch):
     mod.__all__ = ["_private"]
     monkeypatch.setitem(sys.modules, "fake.malformed", mod)
     assert _sage_worker._star_export_screen("fake.malformed") is None
+
+
+def test_shield_moves_the_protocol_off_descriptor_one():
+    """A raw write to descriptor 1 must land in stderr, not the protocol.
+
+    The parent reads JSON responses from the worker's descriptor 1. A child a
+    Sage internal forks -- the pexpect interfaces most visibly -- inherits
+    that descriptor, and one stray line from it desyncs every request after
+    it (redirect_stdout only rebinds Python's sys.stdout, not the fd). The
+    shield dups the pipe to a private stream and points descriptor 1 at
+    stderr; this exercises it with real pipes standing in for both.
+    """
+    import os
+
+    from sagemath_mcp import _sage_worker
+
+    proto_r, proto_w = os.pipe()   # stands in for the protocol pipe on fd 1
+    noise_r, noise_w = os.pipe()   # stands in for stderr on fd 2
+    saved_out, saved_err = os.dup(1), os.dup(2)
+    try:
+        os.dup2(proto_w, 1)
+        os.dup2(noise_w, 2)
+        _sage_worker._shield_protocol_stream()
+        os.write(1, b"raw child noise\n")   # what an inherited descriptor does
+        print("protocol line", file=_sage_worker._protocol_stream(), flush=True)
+    finally:
+        os.dup2(saved_out, 1)
+        os.dup2(saved_err, 2)
+        os.close(saved_out)
+        os.close(saved_err)
+        shielded = _sage_worker._PROTOCOL
+        _sage_worker._PROTOCOL = None
+        shielded.close()
+        os.close(proto_w)
+        os.close(noise_w)
+
+    try:
+        assert os.read(proto_r, 1024) == b"protocol line\n"
+        assert os.read(noise_r, 1024) == b"raw child noise\n"
+    finally:
+        os.close(proto_r)
+        os.close(noise_r)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1674,3 +1674,50 @@ def test_a_successful_save_retires_the_legacy_file(tmp_path):
 
     assert session._persist_path().exists()
     assert not legacy.exists(), "the superseded journal should be retired on success"
+
+
+@pytest.mark.asyncio
+async def test_worker_leads_its_own_process_group(python_settings):
+    """The worker's pid must be its process group id.
+
+    Sage forks helpers of its own (the pexpect interfaces fork GAP and
+    friends); a kill that reaches only the worker leaves those orphaned and
+    computing. start_new_session makes the worker a group leader so the
+    group kill in _kill_worker_group can reap the lot. POSIX only.
+    """
+    import os
+
+    session = SageSession("pgid-session", python_settings)
+    try:
+        await session.evaluate("1 + 1", want_latex=False, capture_stdout=False)
+        assert session._process is not None
+        pid = session._process.pid
+        assert os.getpgid(pid) == pid
+    finally:
+        await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_terminate_kills_the_worker_process_group(monkeypatch, python_settings):
+    """Termination must target the group, not just the worker pid."""
+    import os
+    import signal as signal_module
+
+    killed: list[tuple[int, int]] = []
+    real_killpg = os.killpg
+
+    def recording_killpg(pgid: int, sig: int) -> None:
+        killed.append((pgid, sig))
+        real_killpg(pgid, sig)
+
+    session = SageSession("group-kill-session", python_settings)
+    try:
+        await session.evaluate("1 + 1", want_latex=False, capture_stdout=False)
+        assert session._process is not None
+        pid = session._process.pid
+        monkeypatch.setattr(os, "killpg", recording_killpg)
+        await session._terminate_worker()
+    finally:
+        await session.shutdown()
+
+    assert (pid, signal_module.SIGKILL) in killed


### PR DESCRIPTION
Two robustness holes surfaced by the 2026-08-24 code-level read of the peer Sage MCP servers, both real in our worker:

1. **Orphaned grandchildren.** Sage forks helpers (pexpect interfaces fork GAP and friends); our kills reached only the worker pid, leaving those computing after a cancel or timeout. szeider/mcp-sage's GAP crash-loop incident and GaloisHLee's SIGKILL-orphan pattern are both this hole. Fix: `start_new_session=True` + `os.killpg` in a new `_kill_worker_group()` used by terminate and the shutdown-grace path. `interrupt` deliberately still signals only the worker (Sage forwards SIGINT to its interfaces like the REPL forwards Ctrl-C).

2. **Protocol descriptor inheritance.** The JSON protocol lived on the worker's fd 1, and `redirect_stdout()` rebinds only Python's `sys.stdout` — a child forked by a Sage internal, or a C library writing to the descriptor, landed mid-JSON-line and desynced every subsequent request (scicompute-mcp hit exactly this when a Julia child inherited its transport fds). Fix: at worker entry, dup the pipe to a private protocol stream and point fd 1 at stderr, so raw writes surface as logged noise. In-process tests are unshielded (protocol falls back to `sys.stdout`).

Tests: worker group-leadership and group-kill tests, plus a pipe-based test that a raw `os.write(1, ...)` lands in stderr while the protocol stream stays clean. 907 unit tests at 100% stmt+branch coverage; session/integration/streaming suites green against real Sage (the single integration failure in my local beta9 container is the SnapPy denylist drift owned by #52, not this change — CI runs 10.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135Z8yq1oSbz1WkPXAEKuhb