### PR TITLE
Declare MCP annotations on every tool

### DIFF
--- a/src/sagemath_mcp/tools/algebra.py
+++ b/src/sagemath_mcp/tools/algebra.py
@@ -30,9 +30,10 @@ from ..session import (
     DEFAULT_SESSION_NAME,
 )
 from ..text import SESSION_ARG_DESC as _SESSION_ARG_DESC
+from .hints import COMPUTES
 
 
-@mcp.tool(description="Solve an equation or system of equations")
+@mcp.tool(annotations=COMPUTES, description="Solve an equation or system of equations")
 async def solve_equation(
     equation: Annotated[
         str | list[str],
@@ -86,7 +87,10 @@ _EXACT_SCALAR = (
 )
 
 
-@mcp.tool(description="Multiply two matrices and return the result as nested lists")
+@mcp.tool(
+    annotations=COMPUTES,
+    description="Multiply two matrices and return the result as nested lists",
+)
 async def matrix_multiply(
     matrix_a: Annotated[
         list[list[float | int | str]],
@@ -129,7 +133,7 @@ async def matrix_multiply(
     return {"product": product}
 
 
-@mcp.tool(description=(
+@mcp.tool(annotations=COMPUTES, description=(
         "Linear algebra on one matrix: determinant, inverse, eigenvalues, rank, "
         "reduced row echelon form, transpose. Prefer this over evaluate_sage."
     ))
@@ -183,6 +187,7 @@ async def matrix_operation(
 
 
 @mcp.tool(
+    annotations=COMPUTES,
     description=(
         "Boolean polynomials over GF(2): evaluate, list variables, degree, and "
         "zero/one tests. Prefer this over evaluate_sage for boolean algebra."
@@ -243,6 +248,7 @@ async def boolean_algebra_operation(
 
 
 @mcp.tool(
+    annotations=COMPUTES,
     description="Polynomial ring operations: construct rings "
     "and compute Groebner bases, ideals, quotients"
 )

--- a/src/sagemath_mcp/tools/calculus.py
+++ b/src/sagemath_mcp/tools/calculus.py
@@ -28,9 +28,13 @@ from ..session import (
     DEFAULT_SESSION_NAME,
 )
 from ..text import SESSION_ARG_DESC as _SESSION_ARG_DESC
+from .hints import COMPUTES
 
 
-@mcp.tool(description="Differentiate an expression with respect to a variable")
+@mcp.tool(
+    annotations=COMPUTES,
+    description="Differentiate an expression with respect to a variable",
+)
 async def differentiate_expression(
     expression: Annotated[str, Field(description="Expression to differentiate")],
     variable: Annotated[str, Field(description="Variable for differentiation", default="x")] = "x",
@@ -58,7 +62,10 @@ async def differentiate_expression(
     return {"derivative": result, "order": order}
 
 
-@mcp.tool(description="Integrate an expression (indefinite or definite with bounds)")
+@mcp.tool(
+    annotations=COMPUTES,
+    description="Integrate an expression (indefinite or definite with bounds)",
+)
 async def integrate_expression(
     expression: Annotated[str, Field(description="Expression to integrate")],
     variable: Annotated[str, Field(description="Integration variable", default="x")] = "x",
@@ -108,7 +115,7 @@ async def integrate_expression(
     return {"integral": result, "definite": definite}
 
 
-@mcp.tool(description="Compute the limit of an expression")
+@mcp.tool(annotations=COMPUTES, description="Compute the limit of an expression")
 async def limit_expression(
     expression: Annotated[str, Field(description="Expression to take the limit of")],
     variable: Annotated[str, Field(description="Variable approaching the point")] = "x",
@@ -140,7 +147,7 @@ async def limit_expression(
     return {"limit": result}
 
 
-@mcp.tool(description="Compute a Taylor/Laurent series expansion")
+@mcp.tool(annotations=COMPUTES, description="Compute a Taylor/Laurent series expansion")
 async def series_expansion(
     expression: Annotated[str, Field(description="Expression to expand in series")],
     variable: Annotated[str, Field(description="Variable for expansion")] = "x",
@@ -168,7 +175,7 @@ async def series_expansion(
     return {"series": result, "point": point, "order": order}
 
 
-@mcp.tool(description=(
+@mcp.tool(annotations=COMPUTES, description=(
         "Solve an ordinary differential equation of any order, returning the "
         "general solution with arbitrary constants. Prefer this over evaluate_sage."
     ))
@@ -223,7 +230,7 @@ async def solve_ode(
     return {"solution": result}
 
 
-@mcp.tool(description=(
+@mcp.tool(annotations=COMPUTES, description=(
         "Closed form of a symbolic sum or product over an index variable, "
         "including infinite series. Prefer this over evaluate_sage for summations."
     ))
@@ -260,6 +267,7 @@ async def symbolic_sum(
 
 
 @mcp.tool(
+    annotations=COMPUTES,
     description="Vector calculus operations: gradient, divergence, curl, laplacian"
 )
 async def vector_calculus_operation(

--- a/src/sagemath_mcp/tools/core.py
+++ b/src/sagemath_mcp/tools/core.py
@@ -35,6 +35,7 @@ from ..session import (
     SageProcessError,
 )
 from ..text import SESSION_ARG_DESC as _SESSION_ARG_DESC
+from .hints import COMPUTES, EVALUATES
 
 LOGGER = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ LOGGER = logging.getLogger(__name__)
 # suite, Codex chose evaluate_sage for every single question. The examples below
 # are deliberately restricted to work no dedicated tool performs, so that what
 # this tool shows and what it says agree.
-@mcp.tool(description="""\
+@mcp.tool(annotations=EVALUATES, description="""\
 Run arbitrary SageMath code in a persistent session; variables persist across calls.
 
 LAST RESORT. A dedicated tool exists for most tasks and should be preferred: it \
@@ -193,7 +194,10 @@ def _truncate_stdout(stdout: str) -> str:
     return clipped + "\n… [output truncated]"
 
 
-@mcp.tool(description="Evaluate a SageMath expression and return numeric/string forms")
+@mcp.tool(
+    annotations=COMPUTES,
+    description="Evaluate a SageMath expression and return numeric/string forms",
+)
 async def calculate_expression(
     expression: Annotated[str, Field(description="SageMath expression to evaluate")],
     session: Annotated[str, Field(description=_SESSION_ARG_DESC)] = DEFAULT_SESSION_NAME,
@@ -230,7 +234,7 @@ async def calculate_expression(
     return payload
 
 
-@mcp.tool(description="Simplify a mathematical expression")
+@mcp.tool(annotations=COMPUTES, description="Simplify a mathematical expression")
 async def simplify_expression(
     expression: Annotated[str, Field(description="Expression to simplify")],
     session: Annotated[str, Field(description=_SESSION_ARG_DESC)] = DEFAULT_SESSION_NAME,
@@ -252,7 +256,7 @@ async def simplify_expression(
     return {"simplified": result}
 
 
-@mcp.tool(description="Expand a mathematical expression")
+@mcp.tool(annotations=COMPUTES, description="Expand a mathematical expression")
 async def expand_expression(
     expression: Annotated[str, Field(description="Expression to expand")],
     session: Annotated[str, Field(description=_SESSION_ARG_DESC)] = DEFAULT_SESSION_NAME,
@@ -274,7 +278,7 @@ async def expand_expression(
     return {"expanded": result}
 
 
-@mcp.tool(description="Factor a mathematical expression or integer")
+@mcp.tool(annotations=COMPUTES, description="Factor a mathematical expression or integer")
 async def factor_expression(
     expression: Annotated[str, Field(description="Expression to factor (e.g., 'x^2 - 1' or '60')")],
     session: Annotated[str, Field(description=_SESSION_ARG_DESC)] = DEFAULT_SESSION_NAME,
@@ -296,7 +300,10 @@ async def factor_expression(
     return {"factored": result}
 
 
-@mcp.tool(description="Find a numeric root of an expression or equation in a given interval")
+@mcp.tool(
+    annotations=COMPUTES,
+    description="Find a numeric root of an expression or equation in a given interval",
+)
 async def find_root(
     expression: Annotated[
         str,
@@ -344,6 +351,7 @@ async def find_root(
 
 
 @mcp.tool(
+    annotations=EVALUATES,
     description="Execute SageMath code and stream intermediate print() output "
     "line by line. Final result is returned as usual."
 )

--- a/src/sagemath_mcp/tools/discrete.py
+++ b/src/sagemath_mcp/tools/discrete.py
@@ -28,9 +28,10 @@ from ..session import (
     DEFAULT_SESSION_NAME,
 )
 from ..text import SESSION_ARG_DESC as _SESSION_ARG_DESC
+from .hints import COMPUTES
 
 
-@mcp.tool(description=(
+@mcp.tool(annotations=COMPUTES, description=(
         "Number theory: primality testing, integer factorisation, the next "
         "prime above n, gcd and lcm. Prefer this over evaluate_sage for any of these."
     ))
@@ -83,7 +84,7 @@ async def number_theory_operation(
     return {"operation": operation, "result": result}
 
 
-@mcp.tool(description=(
+@mcp.tool(annotations=COMPUTES, description=(
         "Combinatorics: binomial coefficients, permutations, combinations, "
         "integer partitions, factorial, Catalan, Fibonacci and Bell numbers. "
         "Prefer this over evaluate_sage for any of these."
@@ -153,6 +154,7 @@ async def combinatorics_operation(
 
 
 @mcp.tool(
+    annotations=COMPUTES,
     description="Graph theory: create named graphs and compute properties "
     "(chromatic_number, is_connected, diameter, etc.)"
 )
@@ -227,6 +229,7 @@ async def graph_operation(
 
 
 @mcp.tool(
+    annotations=COMPUTES,
     description="Group theory: construct groups and query properties "
     "(order, is_abelian, center, etc.)"
 )
@@ -274,6 +277,7 @@ async def group_operation(
 
 
 @mcp.tool(
+    annotations=COMPUTES,
     description=(
         "Elliptic curves over Q: rank, torsion order, discriminant, j-invariant, "
         "conductor and generators, from Weierstrass coefficients. Prefer this "
@@ -327,6 +331,7 @@ async def elliptic_curve_operation(
 
 
 @mcp.tool(
+    annotations=COMPUTES,
     description=(
         "Error-correcting codes: length, dimension, minimum distance, rate and "
         "generator matrix for Hamming and generalized Reed-Solomon codes. Prefer "

--- a/src/sagemath_mcp/tools/hints.py
+++ b/src/sagemath_mcp/tools/hints.py
@@ -1,0 +1,67 @@
+"""MCP tool annotations, grouped by what a tool does to the session.
+
+Annotations are advisory metadata for clients (`readOnlyHint`,
+`destructiveHint`, `idempotentHint`, `openWorldHint`) -- an agent UI may use
+them to decide what needs confirmation and what is safe to retry. They are
+hints, not enforcement; the security model does not depend on them.
+
+`openWorldHint` is False on every tool: nothing here reaches beyond the local
+Sage worker. A test in tests/test_tool_inventory.py pins each group's
+membership, so a new tool must say what kind it is.
+"""
+
+from __future__ import annotations
+
+# Deterministic mathematics. These run inside the session worker (so not
+# readOnly -- they cost compute and may warm caches there), but repeating one
+# with the same input adds nothing and destroys nothing.
+COMPUTES: dict[str, bool] = {
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": False,
+}
+
+# Open-ended code in the persistent namespace. `x += 1` twice is not the same
+# as once, so no idempotence is promised.
+EVALUATES: dict[str, bool] = {
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "idempotentHint": False,
+    "openWorldHint": False,
+}
+
+# Session lifecycle that throws state away: cancel and reset discard the
+# namespace, stop discards a whole workspace. The one thing worth a client's
+# confirmation prompt.
+DISCARDS: dict[str, bool] = {
+    "readOnlyHint": False,
+    "destructiveHint": True,
+    "idempotentHint": True,
+    "openWorldHint": False,
+}
+
+# Interrupt stops the computation and keeps every variable -- deliberately not
+# destructive, because that distinction is the reason the tool exists.
+INTERRUPTS: dict[str, bool] = {
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": False,
+}
+
+# Starting a workspace that already exists is a no-op.
+STARTS: dict[str, bool] = {
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": False,
+}
+
+# Pure inspection.
+READS: dict[str, bool] = {
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": False,
+}

--- a/src/sagemath_mcp/tools/plotting.py
+++ b/src/sagemath_mcp/tools/plotting.py
@@ -26,12 +26,16 @@ from ..session import (
     DEFAULT_SESSION_NAME,
 )
 from ..text import SESSION_ARG_DESC as _SESSION_ARG_DESC
+from .hints import COMPUTES
 
 # Samples per axis for the 3D surface. 48x48 keeps the rendered surface smooth
 # while staying well inside the evaluation timeout.
 _PLOT3D_GRID = 48
 
-@mcp.tool(description="Plot a 3D surface of a two-variable expression as base64 PNG")
+@mcp.tool(
+    annotations=COMPUTES,
+    description="Plot a 3D surface of a two-variable expression as base64 PNG",
+)
 async def plot3d_expression(
     expression: Annotated[
         str, Field(description="Expression of two variables (e.g. 'sin(x)*cos(y)')")
@@ -109,7 +113,10 @@ async def plot3d_expression(
     return {"image_base64": result, "format": "png"}
 
 
-@mcp.tool(description="Plot multiple expressions overlaid on a single 2D graph")
+@mcp.tool(
+    annotations=COMPUTES,
+    description="Plot multiple expressions overlaid on a single 2D graph",
+)
 async def plot_multi_expression(
     expressions: Annotated[
         list[str], Field(description="List of expressions to plot (e.g. ['sin(x)', 'cos(x)'])")
@@ -146,7 +153,10 @@ async def plot_multi_expression(
     return {"image_base64": result, "format": "png"}
 
 
-@mcp.tool(description="Plot an expression and return a base64-encoded PNG image")
+@mcp.tool(
+    annotations=COMPUTES,
+    description="Plot an expression and return a base64-encoded PNG image",
+)
 async def plot_expression(
     expression: Annotated[str, Field(description="Expression to plot")],
     variable: Annotated[str, Field(description="Plot variable")] = "x",
@@ -182,6 +192,7 @@ async def plot_expression(
 
 
 @mcp.tool(
+    annotations=COMPUTES,
     description=(
         "Computational geometry on point sets: euclidean distance, polygon area, "
         "polytope volume, convex hull vertices and convexity tests. Prefer this "

--- a/src/sagemath_mcp/tools/session.py
+++ b/src/sagemath_mcp/tools/session.py
@@ -27,6 +27,7 @@ from ..session import (
     SageSessionManager,
 )
 from ..text import SESSION_ARG_DESC as _SESSION_ARG_DESC
+from .hints import DISCARDS, INTERRUPTS, READS, STARTS
 
 DOC_LINKS: list[DocumentationLink] = [
     DocumentationLink(
@@ -44,7 +45,10 @@ DOC_LINKS: list[DocumentationLink] = [
 ]
 
 
-@mcp.tool(description="Reset the SageMath session state for the current MCP session")
+@mcp.tool(
+    annotations=DISCARDS,
+    description="Reset the SageMath session state for the current MCP session",
+)
 async def reset_sage_session(
     session: Annotated[str, Field(description=_SESSION_ARG_DESC)] = DEFAULT_SESSION_NAME,
     ctx: Context | None = None,
@@ -58,6 +62,7 @@ async def reset_sage_session(
 
 
 @mcp.tool(
+    annotations=INTERRUPTS,
     description="Interrupt a running Sage computation while keeping variables defined so far"
 )
 async def interrupt_sage_session(
@@ -83,7 +88,10 @@ async def interrupt_sage_session(
     return ResetResponse(message=f"Interrupted session '{session}'; state preserved")
 
 
-@mcp.tool(description="Cancel any running Sage computation and restart the worker")
+@mcp.tool(
+    annotations=DISCARDS,
+    description="Cancel any running Sage computation and restart the worker",
+)
 async def cancel_sage_session(
     session: Annotated[str, Field(description=_SESSION_ARG_DESC)] = DEFAULT_SESSION_NAME,
     ctx: Context | None = None,
@@ -100,7 +108,10 @@ async def cancel_sage_session(
     return ResetResponse(message="Session cancelled and restarted")
 
 
-@mcp.tool(description="Start a named Sage workspace with its own independent variables")
+@mcp.tool(
+    annotations=STARTS,
+    description="Start a named Sage workspace with its own independent variables",
+)
 async def start_sage_session(
     name: Annotated[str, Field(description="Workspace name, e.g. 'curves' or 'scratch'")],
     ctx: Context | None = None,
@@ -119,7 +130,7 @@ async def start_sage_session(
     return ResetResponse(message=f"Session '{name}' ready")
 
 
-@mcp.tool(description="List the named Sage workspaces belonging to this client")
+@mcp.tool(annotations=READS, description="List the named Sage workspaces belonging to this client")
 async def list_sage_sessions(ctx: Context | None = None) -> dict:
     """Report every workspace for this client, with liveness and statement counts."""
     if ctx is None or ctx.session_id is None:
@@ -128,7 +139,7 @@ async def list_sage_sessions(ctx: Context | None = None) -> dict:
     return {"sessions": sessions, "count": len(sessions)}
 
 
-@mcp.tool(description="Stop a named Sage workspace and release its worker")
+@mcp.tool(annotations=DISCARDS, description="Stop a named Sage workspace and release its worker")
 async def stop_sage_session(
     name: Annotated[str, Field(description="Workspace name to stop")],
     ctx: Context | None = None,

--- a/src/sagemath_mcp/tools/stats.py
+++ b/src/sagemath_mcp/tools/stats.py
@@ -29,9 +29,10 @@ from ..session import (
     DEFAULT_SESSION_NAME,
 )
 from ..text import SESSION_ARG_DESC as _SESSION_ARG_DESC
+from .hints import COMPUTES
 
 
-@mcp.tool(description=(
+@mcp.tool(annotations=COMPUTES, description=(
         "Descriptive statistics for a list of numbers: mean, median, population "
         "and sample variance and standard deviation, min and max. Prefer this "
         "over evaluate_sage for summary statistics."
@@ -77,6 +78,7 @@ async def statistics_summary(
 
 
 @mcp.tool(
+    annotations=COMPUTES,
     description="Probability distribution operations: PDF, CDF, quantile, mean, variance, sampling"
 )
 async def distribution_operation(

--- a/tests/test_tool_inventory.py
+++ b/tests/test_tool_inventory.py
@@ -167,3 +167,40 @@ def test_matrix_entries_advertise_exact_integers(tool: str, parameter: str) -> N
     tools = asyncio.run(_collect())["tools"]
     entry = tools[tool]["input_schema"]["properties"][parameter]["items"]["items"]
     assert _accepts_string(entry), f"{tool}.{parameter} entries cannot carry an exact integer"
+
+
+async def test_every_tool_declares_its_annotations():
+    """Each tool says what kind it is; the risky memberships are pinned.
+
+    Annotations are advisory (clients may gate confirmation prompts on
+    destructiveHint or retries on idempotentHint), so the dangerous claims are
+    asserted exactly: nothing may become destructive, read-only or
+    non-idempotent -- or stop being it -- without this test changing too. See
+    src/sagemath_mcp/tools/hints.py for the groups.
+    """
+    from sagemath_mcp import server
+
+    tools = await server.mcp.list_tools()
+    hints = {tool.name: tool.annotations for tool in tools}
+
+    missing = sorted(name for name, a in hints.items() if a is None)
+    assert not missing, f"tools without annotations: {missing}"
+
+    destructive = {name for name, a in hints.items() if a.destructiveHint}
+    assert destructive == {
+        "cancel_sage_session",
+        "reset_sage_session",
+        "stop_sage_session",
+    }, "destructive means 'discards session state'; nothing else qualifies"
+
+    read_only = {name for name, a in hints.items() if a.readOnlyHint}
+    assert read_only == {"list_sage_sessions"}
+
+    non_idempotent = {name for name, a in hints.items() if not a.idempotentHint}
+    assert non_idempotent == {"evaluate_sage", "evaluate_sage_streaming"}, (
+        "open-ended code is the only surface where repeating is not the same "
+        "as doing it once"
+    )
+
+    open_world = {name for name, a in hints.items() if a.openWorldHint}
+    assert not open_world, "nothing here reaches beyond the local Sage worker"


### PR DESCRIPTION
Adopted from the 2026-08-24 peer code read (the one thing justice8096's server does that we didn't): every tool now declares MCP annotations (`readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint`) via six semantic groups in `tools/hints.py`.

The interesting calls:
- **DISCARDS** (`destructiveHint: true`) is exactly `cancel_sage_session`, `reset_sage_session`, `stop_sage_session` — the tools that throw session state away.
- **INTERRUPTS** is deliberately *not* destructive: keeping the variables is the reason the tool exists over cancel.
- **EVALUATES** (`evaluate_sage`, `evaluate_sage_streaming`) makes no idempotence promise — `x += 1` twice is not once.
- `openWorldHint: false` everywhere.

A new inventory test pins the risky memberships exactly, so nothing can silently become (or stop being) destructive/read-only/non-idempotent. The tool snapshot is unchanged (names, schemas, descriptions untouched). 905 unit tests, 100% stmt+branch coverage, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135Z8yq1oSbz1WkPXAEKuhb