### PR TITLE
Coach the retry in the evaluation-timeout message

### DIFF
--- a/src/sagemath_mcp/session.py
+++ b/src/sagemath_mcp/session.py
@@ -377,8 +377,17 @@ class SageSession:
             # Deliberately no drain here. Waiting on the caller's callback held
             # the TimeoutError until the callback was released, so the caller
             # waited indefinitely for news of a computation already abandoned.
+            # The message coaches the model, not just the operator: it says
+            # what happened to the state and which tool fits the retry. A bare
+            # "timed out" reads as "try the same call again", which repeats the
+            # timeout and discards a fresh namespace each time.
             raise TimeoutError(
-                f"Sage evaluation timed out after {effective_timeout:.2f}s"
+                f"Sage evaluation timed out after {effective_timeout:.2f}s. "
+                "The worker was restarted and the session's variables were "
+                "discarded. Retry with a larger per-call `timeout`; for long "
+                "computations prefer evaluate_sage_streaming to watch "
+                "progress, and interrupt_sage_session to stop one while "
+                "keeping its variables."
             ) from exc
         except asyncio.CancelledError:
                 # The caller went away, but the worker is still computing: the

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1674,3 +1674,30 @@ def test_a_successful_save_retires_the_legacy_file(tmp_path):
 
     assert session._persist_path().exists()
     assert not legacy.exists(), "the superseded journal should be retired on success"
+
+
+@pytest.mark.asyncio
+async def test_timeout_message_coaches_the_retry(python_settings):
+    """The timeout error must say what happened to the state and what to do.
+
+    Clients here are models that retry on what they are told. A bare "timed
+    out" invites resending the same call, which times out again and discards
+    a fresh namespace each round; the message names the per-call `timeout`,
+    the streaming tool, and the interrupt-keeps-variables distinction instead.
+    """
+    session = SageSession("coaching-timeout", python_settings)
+    try:
+        with pytest.raises(TimeoutError) as excinfo:
+            await session.evaluate(
+                "sum(range(80000000))",
+                want_latex=False,
+                capture_stdout=False,
+                timeout_seconds=0.3,
+            )
+        message = str(excinfo.value)
+        assert "variables were discarded" in message
+        assert "`timeout`" in message
+        assert "evaluate_sage_streaming" in message
+        assert "interrupt_sage_session" in message
+    finally:
+        await session.shutdown()


### PR DESCRIPTION
Small message-quality change from the 2026-08-24 peer code read: the timeout error now tells the model what happened to its state and which tool fits the retry, instead of a bare "timed out" that invites resending the same call (each round of which restarts the worker and discards a fresh namespace).

Before: `Sage evaluation timed out after 30.00s`
After: adds "The worker was restarted and the session's variables were discarded. Retry with a larger per-call \`timeout\`; for long computations prefer evaluate_sage_streaming to watch progress, and interrupt_sage_session to stop one while keeping its variables."

The tool layer already relays `str(exc)`, so this flows to the client unchanged. New test pins the coaching content with a genuine timeout. 905 unit tests, 100% coverage, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135Z8yq1oSbz1WkPXAEKuhb