### PR TITLE
Cover the peer field's workloads: lattice reduction and GAP structure

### DIFF
--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -200,3 +200,56 @@ async def test_use_cases_cover_the_sympy_mcp_showcase(monkeypatch):
     finally:
         await manager.shutdown()
         runtime.SESSION_MANAGER = original_manager
+
+
+@requires_sage
+@pytest.mark.asyncio
+async def test_use_cases_cover_the_peer_field_workloads(monkeypatch):
+    """The workloads the other Sage MCP servers demonstrate themselves with.
+
+    Harvested from the 2026-08-24 peer code read; sympy-mcp's showcase has its
+    own test above. Two peers carry mathematics ours never pinned:
+
+    GaloisHLee/mcp-server-sagemath ships a manual lattice workout (its only
+    substantial test client): an integer matrix through det, LLL reduction and
+    Hermite normal form -- lattice/crypto territory no test here exercised.
+
+    szeider/mcp-sage's one hard-won defence is a GAP crash-loop guard, added
+    after Graph.automorphism_group().structure_description() fork-bombed the
+    pexpect GAP interface during their NeSy-paper experiments. On this server
+    the call runs through libgap in-process (0.1s, no forking), and this test
+    pins exactly that: the policy admits the mathematics, and the answer comes
+    back through the worker rather than a runaway interface. If a Sage upgrade
+    ever routes it back through a forking interface, the process-group kill
+    from the same survey is the containment.
+    """
+    original_manager = runtime.SESSION_MANAGER
+    settings = SageSettings()
+    manager = SageSessionManager(settings)
+    monkeypatch.setattr(runtime, "SESSION_MANAGER", manager)
+
+    ctx = FakeContext("peer-field-workloads")
+
+    try:
+        # GaloisHLee's lattice workout, made deterministic.
+        det = await server.evaluate_sage(
+            "A = matrix(ZZ, [[10, -3, 2], [4, 7, -5], [1, 1, 9]])\nA.det()",
+            ctx=ctx,
+        )
+        assert det.result == "797"
+        lll = await server.evaluate_sage("A.LLL().rows()", ctx=ctx)
+        assert lll.result == "[(1, 1, 9), (4, 7, -5), (10, -3, 2)]"
+        hermite = await server.evaluate_sage("A.hermite_form().rows()", ctx=ctx)
+        assert hermite.result == "[(1, 0, 554), (0, 1, 252), (0, 0, 797)]"
+
+        # szeider's graph-automorphism experiment, structure description included.
+        order = await server.evaluate_sage(
+            "G = graphs.PetersenGraph().automorphism_group()\nG.order()",
+            ctx=ctx,
+        )
+        assert order.result == "120"
+        structure = await server.evaluate_sage("G.structure_description()", ctx=ctx)
+        assert structure.result == "'S5'"  # a Python str, so the repr keeps its quotes
+    finally:
+        await manager.shutdown()
+        runtime.SESSION_MANAGER = original_manager


### PR DESCRIPTION
Completes the peer-test harvest the 2026-08-24 code read enabled. An audit of the other Sage MCP servers' suites found almost nothing to take directly — szeider ships zero tests, justice8096's vitest suite has no runner and asserts file structure, scicompute's 79 lines don't touch Sage, and sympy-mcp's showcase already landed as #54. What remained were two *workloads*:

- **GaloisHLee's lattice workout** (its only substantial test client): integer matrix → `det` (797), `LLL().rows()`, `hermite_form().rows()` — lattice/crypto mathematics with no prior coverage in this suite.
- **szeider's GAP battle scar**: `graphs.PetersenGraph().automorphism_group().structure_description()` is the exact call that fork-bombed their pexpect GAP interface (their only hard-won defence is a crash-loop guard for it). Here it runs via libgap in-process in ~0.1 s; the test pins that the policy admits the mathematics and the call stays healthy. If a Sage upgrade reroutes it through a forking interface, #55's process-group kill is the containment and this test is the alarm.

All through `evaluate_sage` in one session, state carried across calls. Verified against real Sage (all three use-case tests green in the container); lint and unit gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135Z8yq1oSbz1WkPXAEKuhb