### PR TITLE
Refresh docs for the post-review state (40 tools, workspace handles, /ready)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 
 ## Where Code Goes
 - A new tool belongs in the matching `src/sagemath_mcp/tools/` module (`core`, `calculus`,
-  `algebra`, `discrete`, `stats`, `plotting`, `session`, `diagnostics`) and must be listed in
+  `algebra`, `discrete`, `stats`, `plotting`, `session`, `diagnostics`, `verify`) and must be listed in
   `tools/__init__.py` -- a module missing from that list registers nothing.
 - Decorate against `mcp` imported from `..app`. Never use FastMCP's `mount`/`import_server`
   to compose them: it prefixes tool names, renaming every tool a client has configured.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -5,7 +5,7 @@ SageMath MCP server.
 
 > **SageMath itself is required, not optional.** Installing this package gives
 > you the MCP server; it does not give you Sage. Without a Sage runtime the
-> server starts and advertises all 39 tools, and then every evaluation fails
+> server starts and advertises all 40 tools, and then every evaluation fails
 > with `Unable to locate Sage executable 'sage'`. The supported way to supply
 > one is the Docker container below — the project is built and tested against
 > **SageMath 10.9**, and the set of names callers may use is generated from that

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Whether the task is symbolic calculus, number theory, linear algebra, differenti
 │  app.py + tools/ --- FastMCP 3.x Application                    │
 │                                                                 │
 │  ┌─────────────┐  ┌──────────────┐  ┌────────────────────────┐  │
-│  │ 39 MCP Tools│  │ 3 Resources  │  │ Middleware             │  │
+│  │ 40 MCP Tools│  │ 3 Resources  │  │ Middleware             │  │
 │  │ (evaluate,  │  │ (session,    │  │ - Request logging      │  │
 │  │  solve,     │  │  monitoring, │  │ - Catalogue cache only │  │
 │  │  diff, ...) │  │  docs)       │  │ - Progress heartbeats  │  │
@@ -831,7 +831,7 @@ an idle cull ends it); it is not a cross-restart recovery token.
 #### `check_sage_health`
 
 The MCP-level readiness probe, for stdio clients that cannot reach the HTTP
-`/health` route. It exercises the real path -- worker spawn, protocol round
+`/ready` route. It exercises the real path -- worker spawn, protocol round
 trip, evaluation of `1+1` -- and reports failure in its result rather than
 erroring, so an agent can always call it before committing to a workflow.
 
@@ -1371,7 +1371,7 @@ sagemath-mcp/
 
 | Component | Version | Purpose |
 |-----------|---------|---------|
-| [FastMCP](https://gofastmcp.com/) | 3.2+ | MCP server framework (tools, resources, middleware) |
+| [FastMCP](https://gofastmcp.com/) | >=3.4.7,<4 | MCP server framework (tools, resources, middleware); capped below 4, which breaks cross-client session isolation |
 | [MCP SDK](https://github.com/modelcontextprotocol/python-sdk) | 1.27+ | Model Context Protocol implementation |
 | [Pydantic](https://docs.pydantic.dev/) | 2.12+ | Data validation and serialization for all models |
 | [anyio](https://anyio.readthedocs.io/) | 4.13+ | Async runtime abstraction |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,19 @@
 
 This document tracks planned improvements to the SageMath MCP server, organized by priority and effort. The goal is to strengthen the server's position as a universal mathematics MCP server that enables LLMs to perform any symbolic or discrete mathematical operation.
 
-**Current state (v0.6.1):** 39 MCP tools (32 Sage-backed, 7 infrastructure) covering calculus, algebra, linear algebra, ODEs, number theory, combinatorics, graph theory, group theory, elliptic curves, coding theory, boolean algebra, polynomial rings, geometry, probability, vector calculus, statistics, 2D/3D plotting, numeric root-finding, incremental streaming, an MCP-level health probe and a documentation lookup. As of 2026-08-24 the suites pass 916 unit tests at 100% statement and branch coverage, over 1,000 collected against a real SageMath 10.9 runtime, and the extended CLI cases across Claude, Gemini and Codex. Counts are a snapshot; the coverage floor is the part CI enforces. Every tool carries MCP annotations (`readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint`), pinned by an inventory test.
+**Current state (last release v0.6.1; the work below is on `main`, unreleased):**
+40 MCP tools (33 Sage-backed, 7 infrastructure) covering calculus, algebra,
+linear algebra, ODEs, number theory, combinatorics, graph theory, group theory,
+elliptic curves, coding theory, boolean algebra, polynomial rings, geometry,
+probability, vector calculus, statistics, 2D/3D plotting, numeric root-finding,
+claim verification (`verify_claim`), incremental streaming, an MCP-level health
+probe and a documentation lookup. As of 2026-09-06 the suites pass ~977 unit
+tests at 100% statement and branch coverage, over 1,130 collected against a real
+SageMath 10.9 runtime, and the extended CLI cases across Claude, Gemini and Codex
+(run locally; the keys are deliberately not in CI). Counts are a snapshot; the
+coverage floor is the part CI enforces. Every tool carries MCP annotations
+(`readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint`), pinned by an
+inventory test.
 
 Integration coverage now includes every tool exercised against the examples in its own
 documentation, and a syntax matrix over the input spellings each tool must accept. Both
@@ -28,6 +40,37 @@ The 2026-08-13 review and the security rounds that followed are all recorded in
 [REVIEW_ACTIONS.md](REVIEW_ACTIONS.md) — 34 items, each with its reproduction,
 fix and regression test. All are closed; item 7's distribution half resolved on
 2026-08-24 (below).
+
+**The 2026-09-06 external review is fully worked through** (two rounds, merged in
+PR #61). Every concrete finding is closed, each with a regression test; the
+details are in [CHANGELOG.md](CHANGELOG.md) under *Unreleased*. What it produced:
+
+- **`verify_claim`** shipped, then hardened for soundness after the second round —
+  it never labels approximate arithmetic or an out-of-domain sample as an exact
+  result (see the field-survey item below).
+- **Portable workspace handles.** `start_sage_session` issues an unguessable
+  bearer `workspace_token` that addresses one workspace independently of the
+  transport-level MCP session id — the direction the 2026-07-28 MCP spec's
+  retirement of protocol-level sessions points to. This closes the last of the
+  session-ergonomics gap the survey called out. Names keep transport-scoped
+  isolation; the fastmcp cap (below) stays until handles are validated over real
+  transports.
+- **fastmcp pinned `>=3.4.7,<4`** — 4.0.3 breaks cross-client session isolation
+  (REVIEW_ACTIONS item 68). A fresh install otherwise resolves it.
+- **Session/worker robustness** — serialized worker startup (no double-launch
+  race), a configurable session ceiling, helper-tool evaluations now counted in
+  the metrics, and a real `/ready` probe that evaluates `1+1` on the backend.
+- **Release & onboarding** — every publish gated on a tag *push* (a dry-run
+  dispatch could reach PyPI), the release publishes the exact image its smoke
+  test verified, the README `docker run` carries the Compose hardening on
+  loopback, and the dev-container scripts pin the Dockerfile's Sage tag.
+- **Honest scope docs** — "full access / run any SageMath code" replaced with the
+  deny-by-default subset, and the specialized-tools-use-a-fresh-namespace
+  semantics surfaced where the model reads them.
+
+One non-blocking note from the review remains open, tracked in TODO.md: the
+verifier trusts Sage's own evaluation semantics for the exact-comparison rung,
+which the 0.7.0 release is the natural point to revisit before shipping.
 
 Distribution is settled: the server is listed on the **official MCP registry**
 (`io.github.XBP-Europe/sagemath-mcp`, published by the release pipeline) and on
@@ -147,7 +190,14 @@ documentation rather than surface:
       interval evidence always a certified enclosure), and `supported` always
       carries its evidence. The landing costs were paid: inventory snapshot,
       real-Sage ladder cases in `tests/test_verify.py`, and bypass tests that
-      the claim string cannot reach anything the evaluate gate refuses.
+      the claim string cannot reach anything the evaluate gate refuses. A second
+      external-review round (2026-09-06) closed two soundness holes: a comparison
+      over machine floats (`RR(1) + RR(1)/10^20 == RR(1)`) is now `supported` via
+      a `float_comparison` method, never `proved` — the operands are inspected
+      for exactness, decimal literals read as exact rationals — and a sampled
+      counterexample can no longer fall outside a stated domain (`x != 1/2` under
+      `assume(x, 'integer')` is not refuted at 1/2). Assumptions are named in the
+      evidence of any verdict that relied on them.
 - [ ] **Outcome benchmarks.** Axiom publishes GSM8K / MATH accuracy deltas;
       this project's doctest corpus sweep proves the guardrails do not refuse
       mathematics, which is a different claim from "models get more answers
@@ -160,16 +210,22 @@ documentation rather than surface:
       in the README. Runs where the CLI nightlies run — never CI-gated, because
       the number measures the client model as much as the server.
 - [ ] **Passagemath runtime for install footprint.** "Where this project is
-      behind" item 4 above, now with a route: passagemath ships SageMath as
-      modularized pip distributions, so `pip install "sagemath-mcp[passagemath]"`
-      could stand up the 32 Sage-backed tools without the ~3 GB image or a local
-      Sage build. The three generated artifacts (allowlist, star exports, baked
-      denylist) are derived from *the installed Sage*, so the passagemath
-      namespace needs its own reviewed set: generate both variants with the
-      existing scripts, bake both, select by probing the runtime at worker start,
-      and extend the weekly drift job to cover both. The open design cost is
-      exactly that doubling — two artifact sets to review on every engine bump —
-      and it is priced in, not discovered later.
+      behind" item 4 above. **Evaluated 2026-09-06**
+      ([docs/passagemath_evaluation.md](docs/passagemath_evaluation.md), verified
+      empirically): verdict **adopt, pinned to a verified release**, and the fit
+      is better than this sketch assumed — `pip install passagemath-standard`
+      yields a runtime where `from sage.all import *` works, `_sage_worker.py`
+      runs unmodified, and all 33 Sage-backed tool domains pass on 10.8.9, at
+      ~1 GB download / 3.8 GB disk / ~1 min versus the ~3 GB image. Two blockers
+      before it ships: (1) the star-exports/denylist derivation is layout-
+      sensitive and over-fires under the modular layout — the real engineering,
+      ~1–2 days, and it overlaps the "classify rather than accept" allowlist item
+      in TODO.md; (2) the full suite and doctest corpus sweep run against the pin.
+      Don't track their latest release: 10.8.10/10.8.11 each shipped a broken core
+      backend on Linux x86_64 (found in the evaluation, not their tracker), so an
+      exact pin plus a cold-install smoke gate in CI, which folds their release
+      risk into this project's existing engine-bump discipline. The priced-in cost
+      is still the two artifact sets to review on every engine bump.
 - [x] **Manifolds and GR: document, don't build.** *Done, 2026-08-24.* sympy-mcp's
       tensor/GR tools (Schwarzschild/Kerr metrics, Ricci/Einstein tensors) are its
       one breadth advantage, and Sage has the stronger machinery underneath
@@ -208,15 +264,17 @@ roadmap reflects what the survey actually changed:
   and szeider's `structure_description()` GAP case, pinned in `test_use_cases.py`.
 
 The still-open feature above — outcome benchmarks — plus the passagemath
-runtime are what remain of the survey; `verify_claim` shipped 2026-09-06.
+runtime are what remain of the survey; `verify_claim` shipped 2026-09-06, and
+portable workspace handles closed the session-ergonomics gap the same day.
 
 ---
 
 ## Explicitly not planned
 
-**More domain tools.** At 37 the surface already exceeds every peer. The gaps that
-matter are distribution and session ergonomics, not coverage. (`verify_claim` in the
-field-survey section is not an exception to this: it is a checking primitive over
+**More domain tools.** At 40 the surface already exceeds every peer. The gaps that
+matter are distribution and session ergonomics, not coverage — and session
+ergonomics is now largely closed (named workspaces, interrupt, portable handles).
+(`verify_claim` is not an exception to this: it is a checking primitive over
 claims, not another slice of mathematical coverage.)
 
 ---

--- a/TESTING.md
+++ b/TESTING.md
@@ -21,6 +21,8 @@ that gap.
 | `test_sage_worker.py` | no | Worker protocol, the streaming stdout buffer, interrupt and startup-failure paths |
 | `test_security_bypass.py` | no | Every sandbox escape found so far, each one a regression test |
 | `test_cache_isolation.py` | no | Two clients must not share cached tool responses |
+| `test_workspace_handles.py` | no | Portable workspace handles: issuance, resolution independent of the transport session, fail-closed on unknown/revoked handles, and no leakage through listings or the session resource |
+| `test_robustness.py` | **partly** | Session/worker robustness: the startup race (no double-launch), the session ceiling, helper-tool evaluations reaching the metrics, and the `/ready` readiness endpoint |
 | `test_diagnostics.py` | no | The health probe (`check_sage_health`, reports unhealthy rather than erroring) and the doc lookup (`lookup_sage_doc`, links plus whether a name is offered to caller code) |
 | `test_tool_inventory.py` | no | The MCP contract: tool names, schemas and descriptions against a committed snapshot, and that every tool declares its MCP annotations with the destructive/read-only/non-idempotent memberships pinned |
 | `test_readme_badges.py` | no | README badge claims against the files that decide them |
@@ -28,6 +30,7 @@ that gap.
 | `test_math_suite.py` | no | Mathematical results the pure-Python worker can check |
 | `test_cli_harness.py` | no | The extended CLI harness's own verdict logic, fed synthetic wire logs |
 | `test_math_coverage.py` | **partly** | Mathematics that must *work*: binding forms and allowlist reachability without Sage, then truths Sage evaluates, equivalent spellings and preparser behaviour with it |
+| `test_verify.py` | **partly** | The `verify_claim` proof ladder: the comparison-side split, exact-decimal rewriting and injection guards without Sage, then the verdicts (proved/refuted/supported/undecided, `float_comparison`, domain-aware sampling) against real Sage |
 | `test_research_workflows.py` | **yes** | Multi-step sessions on open problems — Collatz, Goldbach, twin primes, odd perfect numbers, zeta zeros, BSD, Erdős–Straus, three cubes, abc. The realistic workload, and the strongest stress on the allowlist |
 | `test_numerical_workflows.py` | **yes** | Floating point, where the remembered answer is wrong: cancellation, conditioning, Newton's rate, order of accuracy, CFL, stiffness, quadrature over the wrong domain |
 | `test_physics_workflows.py` | **yes** | Physics sessions that end at a measured number — Wien and the Sun's temperature, Stefan–Boltzmann, Mercury's 43″/century, the oscillator ladder, anharmonic diagonalisation, phonons, Maxwell, the Bohr radius, a decay fit, the double pendulum |

--- a/docs/mcp_quickstart.md
+++ b/docs/mcp_quickstart.md
@@ -30,7 +30,7 @@ All tools use **SageMath** as the computation backend unless noted.
 - **Session Management:** `start_sage_session`, `list_sage_sessions`, `stop_sage_session`,
   `reset_sage_session`, `interrupt_sage_session` (stops the computation, keeps the variables),
   `cancel_sage_session` (restarts the worker, discards them).
-- **Infrastructure:** `/health` endpoint (HTTP only).
+- **Infrastructure:** `/health` (liveness) and `/ready` (readiness — evaluates `1+1` on the backend) endpoints (HTTP only).
 - **Resources:** `resource://sagemath/session/{scope}`, `resource://sagemath/monitoring/{scope}`,
   `resource://sagemath/docs/{scope}`.
 - **Deployment:** Local development via `uv run sagemath-mcp`, Docker Compose on `http://127.0.0.1:8314/mcp`,

--- a/src/sagemath_mcp/tools/diagnostics.py
+++ b/src/sagemath_mcp/tools/diagnostics.py
@@ -1,7 +1,7 @@
 """Agent-facing diagnostics: a health probe and documentation lookup.
 
 Both adopted from the 2026-08-24 peer survey. Stdio clients cannot reach the
-HTTP ``/health`` route, so agents had no way to check readiness before
+HTTP ``/ready`` route, so agents had no way to check readiness before
 committing to a workflow; and models routinely want the Sage documentation
 for a name, where a static URL map answers without costing a worker round
 trip.
@@ -51,7 +51,7 @@ async def check_sage_health(
 ) -> dict:
     """Answer "can this server do mathematics for me right now?" cheaply.
 
-    The HTTP ``/health`` route answers the same question for Kubernetes, but a
+    The HTTP ``/ready`` route answers the same question for Kubernetes, but a
     stdio client cannot reach it. This is the MCP-level equivalent, and it
     exercises the real path -- worker spawn, protocol round trip, evaluation --
     not just process liveness.


### PR DESCRIPTION
Follow-up to #61: brings the documentation into line with what merged, now that the 2026-09-06 external review is closed.

## ROADMAP.md
- Current-state line now reads **40 tools / 33 Sage-backed** (marked as on `main`, unreleased; last release still v0.6.1).
- New subsection recording the 2026-09-06 external review as **fully worked through** (what it delivered: `verify_claim` + soundness fixes, portable workspace handles, the fastmcp<4 cap, session/worker robustness, release guards, onboarding hardening, honest scope docs).
- `verify_claim` item notes the second-round soundness fixes (float comparisons, domain-aware sampling).
- Passagemath item moves from a **planned route** to the **delivered evaluation** (verdict: adopt, pinned), pointing at `docs/passagemath_evaluation.md`.

## Stale current-state claims corrected
- Tool count: `INSTALLATION.md`, the README architecture box (39 → 40).
- FastMCP requirement: README deps table now `>=3.4.7,<4` to match the cap.
- `tools/` module list in `AGENTS.md` gains `verify`.
- Quickstart infrastructure line adds `/ready`.
- `check_sage_health`'s HTTP-readiness reference is now `/ready` (README + diagnostics docstrings), since `/health` is liveness-only after the merge.
- `TESTING.md` gains rows for `test_verify.py`, `test_workspace_handles.py`, `test_robustness.py`.

## Left as-is
Dated historical snapshots (the 2026-08-13 survey table, REVIEW_ACTIONS, CHANGELOG release history) are intentionally preserved.

Docs-only, plus two docstring lines in `diagnostics.py` (no schema/snapshot impact). Lint clean; inventory, diagnostics and badge tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)