### PR TITLE
Return plots as MCP image content (fix the flagship visual feature)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,14 @@ here is a breaking change.
 
 ### Fixed
 
+- **Plots now render as images** (2026-09-06 external evaluation).
+  `plot_expression`, `plot3d_expression` and `plot_multi_expression` returned
+  `{"image_base64": ...}` — a JSON dict a client serialised as text, so a plot
+  arrived as a ~200 KB wall of base64 that displayed nothing and ate the context
+  window. They now return proper MCP image content (a `fastmcp` `Image` →
+  `ImageContent`) the client renders inline, at a bounded canvas/DPI (a PNG
+  dropped to ~25 KB), with a new `image_format` argument to choose SVG (vector,
+  smaller for line plots) instead of PNG.
 - **Honest scope language** (2026-09-06 external review). "full access to
   SageMath", "run any SageMath code" and "arbitrary SageMath code" are replaced
   across the README, USAGE and the `evaluate_sage` tool description with the

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Whether the task is symbolic calculus, number theory, linear algebra, differenti
 | **Geometry** | `geometry_operation` | Sage | Distance, polygon area, polytope volume, convex hull, compactness via `Polyhedron` |
 | **Statistics** | `statistics_summary` | Sage | Mean, median, population & sample variance/std dev, min, max |
 | **Probability** | `distribution_operation` | Sage | Normal, exponential, Poisson, chi-squared, Student-t, uniform, beta, gamma; PDF, CDF, quantile, analytic mean/variance, sampling |
-| **Visualization** | `plot_expression`, `plot3d_expression`, `plot_multi_expression` | Sage | 2D plots, 3D surface plots, multi-function overlays as base64-encoded PNG |
+| **Visualization** | `plot_expression`, `plot3d_expression`, `plot_multi_expression` | Sage | 2D plots, 3D surface plots, multi-function overlays, returned as rendered images (PNG or SVG) the client displays |
 | **Numeric methods** | `find_root` | Sage | Numeric root-finding in an interval via Sage's `find_root()`, from an expression or an equation |
 | **Verification** | `verify_claim` | Sage | Independently re-check a stated claim through a proof ladder; answers `proved`, `refuted`, `supported` or `undecided`, always with its evidence |
 | **Vector calculus** | `vector_calculus_operation` | Sage | Gradient, divergence, curl, Laplacian on scalar/vector fields |
@@ -671,7 +671,7 @@ Compute descriptive statistics for a numeric dataset using Sage's `mean()` and `
 
 #### `plot_expression`
 
-Render a 2D plot of an expression and return it as a base64-encoded PNG image. Calls Sage's `plot()` function and serializes the result to an in-memory PNG buffer.
+Render a 2D plot of an expression and return it as MCP image content (PNG by default, or SVG via `image_format`) the client displays inline. Calls Sage's `plot()`, renders to an in-memory buffer at a bounded size, and returns it as an image block rather than a base64 string.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/TODO.md
+++ b/TODO.md
@@ -91,6 +91,80 @@ out of date.
 - [x] Official MCP registry: listed as `io.github.XBP-Europe/sagemath-mcp`,
       published by the release pipeline's `mcp-registry` job. Done.
 
+## From the 2026-09-06 external project evaluation
+
+An outside reviewer went through the repo and the source. Roughly a third of
+their list was already done (tool annotations, the session ceiling, the
+red-team bypass corpus, Dependabot's Docker/Actions coverage, the passagemath
+extra evaluation) or wrong; these are the items that survived as legitimate,
+prioritised. Correctness first, then packaging/adoption.
+
+**Correctness / product**
+
+- [x] **Plots return MCP image content, not a base64 dict.** *Done, 2026-09-06.*
+      `plot_expression`/`plot3d_expression`/`plot_multi_expression` returned
+      `{"image_base64": ...}` — JSON text a client showed as a base64 wall
+      instead of a picture. They now return a `fastmcp` `Image` (rendered
+      `ImageContent`), bounded in size (a PNG dropped ~200 KB → ~25 KB), with an
+      `image_format` option for SVG. Verified against real Sage.
+- [ ] **Audit every tool's return for client-travel**, the same way large
+      integers were fixed — anything "technically returned but practically
+      broken" through an MCP client. The plot fix was the worst case; sweep the
+      rest.
+- [ ] **Optional HTTP auth.** The posture (SECURITY.md: no auth, the container
+      is the boundary, keep it loopback) is deliberate and stays the default,
+      but an optional bearer-token FastMCP auth provider — and making the
+      Dockerfile's `0.0.0.0` bind an explicit, loudly-noted opt-in — is a fair
+      refinement for anyone fronting it. Not a blocker; a deliberate opt-in.
+- [ ] **Mutation-test the security policy.** 100% line coverage proves little
+      for `security.py`/`allowlist.py`; a mutation score (mutmut/cosmic-ray)
+      scoped to them, plus Hypothesis-generated ASTs on top of the existing
+      `test_security_bypass.py` corpus, is a real claim. Publish the number.
+- [ ] **Pre-warm one spare worker** so a session's first call does not pay the
+      `from sage.all import *` startup cost; and **ship MCP prompts** ("prove
+      this identity and verify", "solve step by step") — cheap usage steering.
+
+**Packaging / build hygiene**
+
+- [ ] **Dockerfile `COPY . /workspace`** pulls the whole repo (tests,
+      `external_docs`, the 117 KB review file) into the image and busts the
+      layer cache on every edit. Copy `pyproject.toml` + `src/` (+ README/LICENSE
+      for the build) only, and pin the base image by digest. Consider a slim
+      conda-forge-based variant.
+- [ ] **Reconcile the tool count across files** (README 40, GitHub description
+      40, `server.json` "34") and generate any hardcoded count from
+      `tests/fixtures/tool_inventory.json`, the existing source of truth.
+- [ ] **`external_docs/reference_html`** vendors Sage's own HTML (102 KB) into an
+      MIT repo — fetch at generation time instead of committing it.
+- [ ] **Clear the `sagemath-*` PyPI namespace question** with sage-devel now —
+      Sage upstream owns `sagemath-standard`/`sagemath-symbolics`/… and this is a
+      third-party package in that namespace. A friendly ask today, a forced
+      rename after adoption.
+- [ ] **README is a manual, not a front door** (1,593 lines, 17 badges). Trim to
+      ~150: what it is, one working install path (lead with the GHCR image
+      one-liner, which bundles Sage), one client config, three example prompts,
+      links out. Move the tool reference to `docs/`, drop the embedded changelog,
+      trim badges. Fold in the verified `verify_claim` + doctest-corpus number.
+
+**Adoption (not code)**
+
+- [ ] Reach the actual audience: announce on sage-devel / the Sage Zulip; talk
+      to CoCalc (hosted Sage). Publish the doctest-corpus acceptance % as a
+      benchmark (already generated) — the strongest single credibility claim.
+- [ ] Citability + community: a JOSS paper, a Zenodo DOI, `CITATION.cff`,
+      `SUPPORT.md` (release cadence / what "supported" means), enable GitHub
+      Discussions, label good-first-issues. The bus factor (CODEOWNERS names one
+      person) is what an enterprise evaluator notices.
+- [ ] Extra install paths worth their weekend: a conda-forge recipe (where Sage
+      users actually live), a nix flake (`nix run github:…` incl. Sage), and an
+      `.mcpb` bundle for one-click Claude Desktop install. Trust signals: PyPI
+      Trusted Publishing PEP 740 attestations, an SBOM on releases, SLSA image
+      provenance, an OpenSSF Scorecard badge.
+- [ ] **Measure the tool surface before defending it.** The roadmap argues 40
+      tools is a differentiator; the reviewer argues `evaluate_sage` covers most
+      of it and a 12-tool build might score the same. Use the CLI harness to
+      test a reduced set vs the full catalogue on pass rate before deciding.
+
 Smithery is **not pursued** (decided 2026-08-24). Since its Arcade.dev
 acquisition, `smithery.ai/new` publishes only a public HTTPS endpoint — the
 GitHub/`smithery.yaml` connect is gone. Listing would mean hosting a public,

--- a/USAGE.md
+++ b/USAGE.md
@@ -73,8 +73,8 @@ All math tools use **SageMath** as the computation backend.
 | `combinatorics_operation` | Sage | Binomial, permutations, combinations, partitions, factorial, Catalan, Fibonacci, Bell. |
 | `statistics_summary` | Sage | Compute population & sample mean/variance/std-dev plus min/max. |
 | `distribution_operation` | Sage | Probability distributions: normal, exponential, Poisson, chi-squared, Student-t, uniform, beta, gamma. |
-| `plot_expression` | Sage | Render a 2D plot and return a base64-encoded PNG image. |
-| `plot3d_expression` | Sage | Render a 3D surface plot and return a base64-encoded PNG image. |
+| `plot_expression` | Sage | Render a 2D plot and return it as MCP image content (PNG or SVG via `image_format`) the client displays inline. |
+| `plot3d_expression` | Sage | Render a 3D surface plot and return it as MCP image content the client displays inline. |
 | `plot_multi_expression` | Sage | Overlay multiple functions in a single 2D plot. |
 | `find_root` | Sage | Numeric root-finding in an interval via Sage's `find_root()`. Accepts an expression or an equation (`E - 0.6*sin(E) = 0.75`). |
 | `verify_claim` | Sage | Independently re-check a stated claim (`sin(x)^2 + cos(x)^2 == 1`) through a proof ladder: symbolic prover, exact difference, exact algebraic arithmetic, certified intervals, numeric sampling. Answers `proved`, `refuted`, `supported` or `undecided`, always with its evidence. |
@@ -206,7 +206,7 @@ For HTTP transports, point the client at `http://HOST:PORT/mcp` and enable strea
   | `attrgetter`, `methodcaller`, `itemgetter`, `operator.*` | They fetch attributes by a runtime string, which defeats every other rule here. |
   | `gp`, `maxima`, `singular`, `pari`, … | Each spawns the real program, and those have shell escapes: `pari('system("id")')` ran one. |
   | `cython()`, `sh()`, `load()`, `attach()`, `save`/`dump`/`export` | Compile, run a shell, execute a path, or write files. |
-  | `show`, `view`, `latex`, `html`, `animate`, `oeis` | Write to disk, launch a viewer or reach the network. **Use the plot tools instead** — `plot_expression` and friends return a base64 PNG, which is what you want over an MCP connection anyway. |
+  | `show`, `view`, `latex`, `html`, `animate`, `oeis` | Write to disk, launch a viewer or reach the network. **Use the plot tools instead** — `plot_expression` and friends return rendered MCP image content (PNG or SVG) the client displays, which is what you want over an MCP connection anyway. |
 
   The specialised tools cover most of what people reach for these for.
 - **`'n' is larger than 2^53`**: pass that argument as a decimal string. A JSON

--- a/docs/mcp_quickstart.md
+++ b/docs/mcp_quickstart.md
@@ -22,7 +22,7 @@ All tools use **SageMath** as the computation backend unless noted.
 - **Geometry (Sage):** `geometry_operation` (distance, area, volume, convex hull via Polyhedron).
 - **Statistics (Sage):** `statistics_summary` — mean, median, variance, std dev, min, max.
 - **Probability (Sage):** `distribution_operation` (normal, exponential, Poisson, chi-squared, Student-t, etc.).
-- **Visualization (Sage):** `plot_expression`, `plot3d_expression`, `plot_multi_expression` (base64 PNG).
+- **Visualization (Sage):** `plot_expression`, `plot3d_expression`, `plot_multi_expression` (rendered image content, PNG or SVG).
 - **Numeric Methods (Sage):** `find_root` (root-finding in an interval).
 - **Verification (Sage):** `verify_claim` (re-check a stated comparison through a proof ladder; answers `proved`/`refuted`/`supported`/`undecided` with evidence).
 - **Vector Calculus (Sage):** `vector_calculus_operation` (gradient, divergence, curl, Laplacian).
@@ -73,7 +73,7 @@ The refusals worth knowing before you hit them:
 - **No `show()`, `view()`, `latex()`, `html()` or `animate()`.** This is the one
   that catches people, because `show(plot(...))` is how you would do it in a
   notebook. Over MCP you want **`plot_expression`** and its siblings, which
-  return a base64 PNG the client can actually display; `show` would write a file
+  return rendered image content the client actually displays; `show` would write a file
   on the server and try to open a viewer nobody is looking at.
 - **No file or network access** — `save`, `dump`, `export`, `load`, `attach`,
   `oeis`, `get_remote_file`.
@@ -158,5 +158,6 @@ file or reached the network during testing.
   worker and loses them.
 - Name a workspace (`"session": "curves"`) when a line of work should not be
   disturbed by unrelated calculations.
-- Ask for a plot only when you want the image: it comes back as base64 PNG and is
-  large compared with everything else here.
+- Ask for a plot only when you want the image: it comes back as rendered image
+  content (PNG, or SVG via `image_format`) and is large compared with everything
+  else here; SVG is the lighter choice for line plots.

--- a/src/sagemath_mcp/tools/plotting.py
+++ b/src/sagemath_mcp/tools/plotting.py
@@ -8,11 +8,14 @@ would have prefixed them.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import textwrap
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
+from fastmcp.utilities.types import Image
 from pydantic import Field
 
 from .. import runtime
@@ -32,9 +35,62 @@ from .hints import COMPUTES
 # while staying well inside the evaluation timeout.
 _PLOT3D_GRID = 48
 
+# A returned image travels inside the tool result, so it must stay small: a
+# full-resolution PNG is hundreds of KB, which is a wall of base64 in the
+# client's context. A bounded canvas at a modest DPI keeps a PNG in the tens of
+# KB while staying legible.
+_FIG_INCHES = (7.0, 4.5)
+_FIG_DPI = 110
+
+# The `image_format` argument maps to a matplotlib savefig format and an MCP
+# image mime suffix. SVG is vector text -- far smaller than a PNG for a line
+# plot -- so it is offered for callers that want the lightest result. The map is
+# the only thing interpolated into generated code, never the raw argument.
+_SAVE_FORMAT = {"png": "png", "svg": "svg"}
+_MIME_SUFFIX = {"png": "png", "svg": "svg+xml"}
+
+_ImageFormat = Literal["png", "svg"]
+_IMAGE_FORMAT_DESC = "Image format to return: 'png' (raster) or 'svg' (vector, smaller)"
+
+
+def _savefig_snippet(save_format: str) -> str:
+    """Generated-code tail: size the current `_fig` and render it to base64.
+
+    Every plot tool builds a matplotlib ``Figure`` named ``_fig``; this bounds
+    its canvas and encodes it in the requested format. ``bbox_inches='tight'``
+    trims the margins so the cap is spent on the plot, not whitespace.
+    """
+    return textwrap.dedent(
+        f"""
+        _fig.set_size_inches({_FIG_INCHES[0]}, {_FIG_INCHES[1]})
+        _buf = _io.BytesIO()
+        _fig.savefig(_buf, format='{save_format}', dpi={_FIG_DPI}, bbox_inches='tight')
+        _buf.seek(0)
+        base64.b64encode(_buf.read()).decode('ascii')
+        """
+    )
+
+
+async def _render_image(session, code: str, image_format: str) -> Image:
+    """Run image-generating code and return proper MCP image content.
+
+    The tools used to return ``{{"image_base64": ...}}`` -- a plain dict, which
+    serialises as JSON text, so a client showed a wall of base64 instead of a
+    picture and paid the context cost with nothing to look at. Decoding to bytes
+    and wrapping in ``Image`` yields an ``ImageContent`` block the client renders.
+    """
+    result = await _evaluate_structured(session, code)
+    if not isinstance(result, str):
+        raise ToolError("Plot rendering did not return image data")
+    try:
+        data = base64.b64decode(result, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ToolError(f"Plot rendering returned malformed image data: {exc}") from exc
+    return Image(data=data, format=_MIME_SUFFIX[image_format])
+
 @mcp.tool(
     annotations=COMPUTES,
-    description="Plot a 3D surface of a two-variable expression as base64 PNG",
+    description="Plot a 3D surface of a two-variable expression as a rendered image",
 )
 async def plot3d_expression(
     expression: Annotated[
@@ -46,9 +102,10 @@ async def plot3d_expression(
     x_range_max: Annotated[float, Field(description="X upper bound")] = 5.0,
     y_range_min: Annotated[float, Field(description="Y lower bound")] = -5.0,
     y_range_max: Annotated[float, Field(description="Y upper bound")] = 5.0,
+    image_format: Annotated[_ImageFormat, Field(description=_IMAGE_FORMAT_DESC)] = "png",
     session: Annotated[str, Field(description=_SESSION_ARG_DESC)] = DEFAULT_SESSION_NAME,
     ctx: Context | None = None,
-) -> dict:
+) -> Image:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required for stateful execution")
     session = await runtime.resolve_session(ctx.session_id, session)
@@ -102,20 +159,16 @@ async def plot3d_expression(
         _ax.plot_trisurf(_gx, _gy, _gz, cmap='viridis')
         _ax.set_xlabel({_encode_literal(x_variable)})
         _ax.set_ylabel({_encode_literal(y_variable)})
-        _buf = _io.BytesIO()
-        _fig.savefig(_buf, format='png')
-        _buf.seek(0)
-        base64.b64encode(_buf.read()).decode('ascii')
         """
         )
+        + _savefig_snippet(_SAVE_FORMAT[image_format])
     )
-    result = await _evaluate_structured(session, code)
-    return {"image_base64": result, "format": "png"}
+    return await _render_image(session, code, image_format)
 
 
 @mcp.tool(
     annotations=COMPUTES,
-    description="Plot multiple expressions overlaid on a single 2D graph",
+    description="Plot multiple expressions overlaid on a single 2D graph, as a rendered image",
 )
 async def plot_multi_expression(
     expressions: Annotated[
@@ -124,9 +177,10 @@ async def plot_multi_expression(
     variable: Annotated[str, Field(description="Plot variable")] = "x",
     range_min: Annotated[float, Field(description="Lower bound of plot range")] = -10.0,
     range_max: Annotated[float, Field(description="Upper bound of plot range")] = 10.0,
+    image_format: Annotated[_ImageFormat, Field(description=_IMAGE_FORMAT_DESC)] = "png",
     session: Annotated[str, Field(description=_SESSION_ARG_DESC)] = DEFAULT_SESSION_NAME,
     ctx: Context | None = None,
-) -> dict:
+) -> Image:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required for stateful execution")
     session = await runtime.resolve_session(ctx.session_id, session)
@@ -139,32 +193,30 @@ async def plot_multi_expression(
         _var = var({_encode_literal(variable)})
         _exprs = [sage_eval(e, locals=_locals) for e in {_encode_literal(expressions)}]
         _plt = sum(plot(e, (_var, {range_min}, {range_max})) for e in _exprs)
-        _buf = _io.BytesIO()
         # Graphics.save() needs a filesystem path and rejects a BytesIO with
         # "expected str, bytes or os.PathLike object". Going through the
         # matplotlib figure renders to memory, which the sandbox allows.
-        _plt.matplotlib().savefig(_buf, format='png')
-        _buf.seek(0)
-        base64.b64encode(_buf.read()).decode('ascii')
+        _fig = _plt.matplotlib()
         """
         )
+        + _savefig_snippet(_SAVE_FORMAT[image_format])
     )
-    result = await _evaluate_structured(session, code)
-    return {"image_base64": result, "format": "png"}
+    return await _render_image(session, code, image_format)
 
 
 @mcp.tool(
     annotations=COMPUTES,
-    description="Plot an expression and return a base64-encoded PNG image",
+    description="Plot an expression and return it as a rendered image (PNG or SVG)",
 )
 async def plot_expression(
     expression: Annotated[str, Field(description="Expression to plot")],
     variable: Annotated[str, Field(description="Plot variable")] = "x",
     range_min: Annotated[float, Field(description="Lower bound of plot range")] = -10.0,
     range_max: Annotated[float, Field(description="Upper bound of plot range")] = 10.0,
+    image_format: Annotated[_ImageFormat, Field(description=_IMAGE_FORMAT_DESC)] = "png",
     session: Annotated[str, Field(description=_SESSION_ARG_DESC)] = DEFAULT_SESSION_NAME,
     ctx: Context | None = None,
-) -> dict:
+) -> Image:
     if ctx is None or ctx.session_id is None:
         raise ToolError("MCP context with session_id is required for stateful execution")
     session = await runtime.resolve_session(ctx.session_id, session)
@@ -177,18 +229,15 @@ async def plot_expression(
         _var = var({_encode_literal(variable)})
         _expr = sage_eval({_encode_literal(expression)}, locals=_locals)
         _plt = plot(_expr, (_var, {range_min}, {range_max}))
-        _buf = _io.BytesIO()
         # Graphics.save() needs a filesystem path and rejects a BytesIO with
         # "expected str, bytes or os.PathLike object". Going through the
         # matplotlib figure renders to memory, which the sandbox allows.
-        _plt.matplotlib().savefig(_buf, format='png')
-        _buf.seek(0)
-        base64.b64encode(_buf.read()).decode('ascii')
+        _fig = _plt.matplotlib()
         """
         )
+        + _savefig_snippet(_SAVE_FORMAT[image_format])
     )
-    result = await _evaluate_structured(session, code)
-    return {"image_base64": result, "format": "png"}
+    return await _render_image(session, code, image_format)
 
 
 @mcp.tool(

--- a/tests/fixtures/tool_inventory.json
+++ b/tests/fixtures/tool_inventory.json
@@ -836,12 +836,21 @@
       }
     },
     "plot3d_expression": {
-      "description": "Plot a 3D surface of a two-variable expression as base64 PNG",
+      "description": "Plot a 3D surface of a two-variable expression as a rendered image",
       "input_schema": {
         "additionalProperties": false,
         "properties": {
           "expression": {
             "description": "Expression of two variables (e.g. 'sin(x)*cos(y)')",
+            "type": "string"
+          },
+          "image_format": {
+            "default": "png",
+            "description": "Image format to return: 'png' (raster) or 'svg' (vector, smaller)",
+            "enum": [
+              "png",
+              "svg"
+            ],
             "type": "string"
           },
           "session": {
@@ -887,12 +896,21 @@
       }
     },
     "plot_expression": {
-      "description": "Plot an expression and return a base64-encoded PNG image",
+      "description": "Plot an expression and return it as a rendered image (PNG or SVG)",
       "input_schema": {
         "additionalProperties": false,
         "properties": {
           "expression": {
             "description": "Expression to plot",
+            "type": "string"
+          },
+          "image_format": {
+            "default": "png",
+            "description": "Image format to return: 'png' (raster) or 'svg' (vector, smaller)",
+            "enum": [
+              "png",
+              "svg"
+            ],
             "type": "string"
           },
           "range_max": {
@@ -923,7 +941,7 @@
       }
     },
     "plot_multi_expression": {
-      "description": "Plot multiple expressions overlaid on a single 2D graph",
+      "description": "Plot multiple expressions overlaid on a single 2D graph, as a rendered image",
       "input_schema": {
         "additionalProperties": false,
         "properties": {
@@ -933,6 +951,15 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "image_format": {
+            "default": "png",
+            "description": "Image format to return: 'png' (raster) or 'svg' (vector, smaller)",
+            "enum": [
+              "png",
+              "svg"
+            ],
+            "type": "string"
           },
           "range_max": {
             "default": 10.0,

--- a/tests/test_math_examples.py
+++ b/tests/test_math_examples.py
@@ -27,6 +27,23 @@ from sagemath_mcp.session import SageSessionManager
 
 from .conftest import FakeContext
 
+
+def _result_value(result, key):
+    """Pull the asserted value out of a tool result.
+
+    Plot tools return MCP image content (a ``fastmcp`` ``Image``) rather than a
+    dict; for the plot cases the harness asserts against the base64 image data,
+    exposed under the ``image_base64`` key for continuity with the old shape.
+    """
+    from fastmcp.utilities.types import Image
+
+    if isinstance(result, Image):
+        if key == "image_base64":
+            return result.to_image_content().data
+        raise KeyError(key)
+    return result[key]
+
+
 requires_sage = pytest.mark.skipif(
     shutil.which("sage") is None, reason="Sage executable not available"
 )
@@ -460,10 +477,11 @@ async def test_documented_examples(monkeypatch, tool):
             except Exception as exc:  # report every failure, do not abort the group
                 failures.append(f"{case_id}: raised {type(exc).__name__}: {exc}")
                 continue
-            if key not in result:
+            try:
+                actual = _result_value(result, key)
+            except (KeyError, TypeError):
                 failures.append(f"{case_id}: result has no key {key!r}; got {result!r}")
                 continue
-            actual = result[key]
             if not _matches(expected, actual):
                 wanted = getattr(expected, "__name__", repr(expected))
                 failures.append(f"{case_id}: expected {wanted}, got {actual!r}")
@@ -508,8 +526,9 @@ async def test_plot3d_expression_renders_png(monkeypatch, label, expression):
 
     try:
         result = await S.plot3d_expression(expression, ctx=ctx)
-        assert result["format"] == "png"
-        payload = result["image_base64"]
+        content = result.to_image_content()
+        assert content.mimeType == "image/png"
+        payload = content.data
         # Base64 of the PNG magic bytes.
         assert payload.startswith("iVBORw0KGgo"), f"{label}: not a PNG payload"
         assert len(payload) > 1000, f"{label}: payload suspiciously small"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -737,12 +737,38 @@ async def test_number_theory_invalid_op():
 
 @pytest.mark.asyncio
 async def test_plot_expression(monkeypatch):
-    session = StubSession("'aWdub3JlZA=='")
+    session = StubSession("'aWdub3JlZA=='")  # base64 of b"ignored"
     await _stub_manager(monkeypatch, session)
     ctx = FakeContext()
     result = await server.plot_expression("sin(x)", ctx=ctx)
-    assert result["format"] == "png"
-    assert result["image_base64"] == "aWdub3JlZA=="
+    # Returns MCP image content, not a JSON dict of base64: a client renders it.
+    content = result.to_image_content()
+    assert content.mimeType == "image/png"
+    assert content.data == "aWdub3JlZA=="
+
+
+@pytest.mark.asyncio
+async def test_plot_expression_svg(monkeypatch):
+    session = StubSession("'aWdub3JlZA=='")
+    await _stub_manager(monkeypatch, session)
+    result = await server.plot_expression("sin(x)", image_format="svg", ctx=FakeContext())
+    assert result.to_image_content().mimeType == "image/svg+xml"
+
+
+@pytest.mark.asyncio
+async def test_plot_expression_rejects_malformed_image_data(monkeypatch):
+    session = StubSession("'not!!valid!!base64'")
+    await _stub_manager(monkeypatch, session)
+    with pytest.raises(server.ToolError, match="malformed image data"):
+        await server.plot_expression("sin(x)", ctx=FakeContext())
+
+
+@pytest.mark.asyncio
+async def test_plot_expression_rejects_non_string_result(monkeypatch):
+    session = StubSession("42")  # literal_eval -> int, not an image payload
+    await _stub_manager(monkeypatch, session)
+    with pytest.raises(server.ToolError, match="did not return image data"):
+        await server.plot_expression("sin(x)", ctx=FakeContext())
 
 
 @pytest.mark.asyncio
@@ -1206,14 +1232,13 @@ async def test_combinatorics_no_context():
 
 @pytest.mark.asyncio
 async def test_plot3d_expression(monkeypatch):
-    session = StubSession("'iVBORw0KGgo...'")
+    session = StubSession("'aWdub3JlZA=='")
     await _stub_manager(monkeypatch, session)
     ctx = FakeContext()
     result = await server.plot3d_expression(
         expression="x^2 + y^2", ctx=ctx,
     )
-    assert result["format"] == "png"
-    assert "image_base64" in result
+    assert result.to_image_content().mimeType == "image/png"
 
 
 @pytest.mark.asyncio
@@ -1340,14 +1365,13 @@ async def test_find_root_no_context():
 
 @pytest.mark.asyncio
 async def test_plot_multi_expression(monkeypatch):
-    session = StubSession("'iVBORw0KGgo...'")
+    session = StubSession("'aWdub3JlZA=='")
     await _stub_manager(monkeypatch, session)
     ctx = FakeContext()
     result = await server.plot_multi_expression(
         expressions=["sin(x)", "cos(x)"], ctx=ctx,
     )
-    assert result["format"] == "png"
-    assert "image_base64" in result
+    assert result.to_image_content().mimeType == "image/png"
 
 
 @pytest.mark.asyncio

--- a/tests/test_syntax_variants.py
+++ b/tests/test_syntax_variants.py
@@ -46,6 +46,17 @@ def _is_png(value) -> bool:
     return isinstance(value, str) and value.startswith("iVBORw0KGgo") and len(value) > 1000
 
 
+def _result_value(result, key):
+    """Plot tools return MCP image content; expose its base64 under image_base64."""
+    from fastmcp.utilities.types import Image
+
+    if isinstance(result, Image):
+        if key == "image_base64":
+            return result.to_image_content().data
+        raise KeyError(key)
+    return result[key]
+
+
 # --------------------------------------------------------------------------
 # Equivalence classes: {group: (result key, [(label, call), ...])}
 # Every spelling in a group must yield the same value for that key.
@@ -316,10 +327,11 @@ async def test_equivalent_spellings_agree(monkeypatch, group):
             except Exception as exc:
                 failures.append(f"{label}: raised {type(exc).__name__}: {exc}")
                 continue
-            if key not in result:
+            try:
+                observed[label] = _result_value(result, key)
+            except (KeyError, TypeError):
                 failures.append(f"{label}: result has no key {key!r}; got {result!r}")
                 continue
-            observed[label] = result[key]
     finally:
         await manager.shutdown()
 
@@ -350,7 +362,12 @@ async def test_valid_spellings_are_accepted(monkeypatch, group):
             except Exception as exc:
                 failures.append(f"{label}: raised {type(exc).__name__}: {exc}")
                 continue
-            actual = result.get(key)
+            from fastmcp.utilities.types import Image
+
+            if isinstance(result, Image):
+                actual = result.to_image_content().data if key == "image_base64" else None
+            else:
+                actual = result.get(key)
             if callable(expected):
                 ok = bool(expected(actual))
             elif isinstance(expected, float):


### PR DESCRIPTION
From the 2026-09-06 external project evaluation: the plot tools were effectively broken for their main purpose.

## The bug
`plot_expression`, `plot3d_expression` and `plot_multi_expression` returned `{"image_base64": ..., "format": "png"}` — a plain dict, which FastMCP serialises as JSON **text**. In a client that's a ~200 KB wall of base64 that renders as nothing and eats the context window. For a math server whose flagship demo is a rendered plot, this was a real defect, not a nicety.

## The fix
They now return a `fastmcp` `Image`, which serialises to MCP `ImageContent` the client renders inline. Two things ride along:
- **Bounded size** (figsize + DPI + `bbox_inches='tight'`): a 2D PNG dropped from ~200 KB to **~25 KB** — the context cost was half the problem.
- **New `image_format` argument** offering **SVG** (vector, ~19 KB and sharp for line plots) alongside the default PNG. The value maps to a savefig format and image mime through a fixed table; the raw argument is never interpolated into generated code (the injection guard confirms it).

## Verification
- Real SageMath 10.9: PNG (25 KB), SVG (19 KB, `image/svg+xml`), 3D PNG (116 KB) all return correct mime types and valid image bytes.
- Unit + integration suites green (1137 integration), 100% coverage. The integration harnesses that asserted on `result["image_base64"]` now read the base64 out of the returned image content.

## Also
Records the legitimate items from the external evaluation in `TODO.md` (correctness / packaging / adoption), with this plot fix marked done. About a third of the evaluation was already addressed (tool annotations, the session ceiling, the bypass corpus, Dependabot's Docker/Actions coverage, the passagemath evaluation) or inaccurate; the rest is captured there for prioritisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)