### PR TITLE
Return-shape audit: keep non-finite results valid JSON and shaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ here is a breaking change.
 
 ### Fixed
 
+- **Non-finite results stay valid JSON and keep their shape** (2026-09-06
+  return-shape audit). A `float('inf')`/`nan` serialises to the bare tokens
+  `Infinity`/`NaN`, which are not valid JSON — a strict client rejects the whole
+  response. And a result *containing* one (calculate_expression's
+  `{string, numeric}` for `log(0)`) collapsed entirely to a single
+  double-encoded string, because the `-inf` token in its repr defeated result
+  reconstruction, dropping the documented `numeric` field. Both are fixed
+  centrally, where every helper tool's result passes: reconstruction now accepts
+  `inf`/`nan` at any depth via a bounded literal evaluator (no code execution),
+  and non-finite floats are sent as the strings `Infinity`/`-Infinity`/`NaN`.
+  The rest of the audit was already sound — large integers travel as decimal
+  strings, plots as image content, and ordinary string results are fine.
 - **Plots now render as images** (2026-09-06 external evaluation).
   `plot_expression`, `plot3d_expression` and `plot_multi_expression` returned
   `{"image_base64": ...}` — a JSON dict a client serialised as text, so a plot

--- a/TODO.md
+++ b/TODO.md
@@ -107,10 +107,15 @@ prioritised. Correctness first, then packaging/adoption.
       instead of a picture. They now return a `fastmcp` `Image` (rendered
       `ImageContent`), bounded in size (a PNG dropped ~200 KB → ~25 KB), with an
       `image_format` option for SVG. Verified against real Sage.
-- [ ] **Audit every tool's return for client-travel**, the same way large
-      integers were fixed — anything "technically returned but practically
-      broken" through an MCP client. The plot fix was the worst case; sweep the
-      rest.
+- [x] **Audit every tool's return for client-travel.** *Done, 2026-09-06.*
+      Swept every tool's return. One real class beyond the known ones: a
+      non-finite float (`inf`/`nan`) is invalid JSON (`Infinity`/`NaN` tokens a
+      strict client rejects) and, when nested, defeated result reconstruction so
+      `calculate_expression("log(0)")` dropped its `numeric` field to a
+      double-encoded string. Fixed centrally in `_evaluate_structured` —
+      reconstruction accepts `inf`/`nan`, non-finite floats travel as strings.
+      Everything else already sound (large ints → decimal strings, plots → image
+      content, plain strings fine). `tests/test_codegen.py`.
 - [ ] **Optional HTTP auth.** The posture (SECURITY.md: no auth, the container
       is the boundary, keep it loopback) is deliberate and stays the default,
       but an optional bearer-token FastMCP auth provider — and making the

--- a/src/sagemath_mcp/codegen.py
+++ b/src/sagemath_mcp/codegen.py
@@ -18,6 +18,7 @@ import ast
 import functools
 import io
 import json
+import math
 import re
 import textwrap
 import tokenize
@@ -568,22 +569,35 @@ def _distribution_variance(distribution: str, parameters: list[float]) -> float:
 
 
 def _exactify_large_ints(value):
-    """Return *value* with JSON-unsafe integers rendered as decimal strings.
+    """Return *value* made safe to travel back as JSON, recursively.
 
-    The input guard was only half the problem. Results travel back as JSON
-    numbers, and a JavaScript-based MCP client parses those as IEEE doubles:
-    bell(30) = 846749014511809332450147 reached the Claude CLI as
+    Two hazards, both of which reached a client as a broken or unparseable
+    answer, are neutralised here -- the one place every helper tool's result
+    passes through (`_evaluate_structured`).
+
+    **Large integers.** A JavaScript-based MCP client parses JSON numbers as
+    IEEE doubles: bell(30) = 846749014511809332450147 reached the Claude CLI as
     846749014511809388871680 and was shown as the answer. Nothing errored; the
-    number was simply wrong, which is the worst way for this to fail.
+    number was simply wrong, which is the worst way for this to fail. Above 2^53
+    the exact value is therefore sent as a decimal string, mirroring what the
+    input side already demands. Smaller integers keep their type.
 
-    Above 2^53 the exact value is therefore sent as a string, mirroring what the
-    input side already demands for the same reason. Smaller integers keep their
-    type, so ordinary results are unchanged.
+    **Non-finite floats.** `float('inf')`, `-inf` and `nan` serialise to the
+    bare tokens `Infinity`/`-Infinity`/`NaN` (Python's json emits them by
+    default), which are not valid JSON -- a strict client's `JSON.parse` rejects
+    the whole response, so a `distribution_operation` quantile at p=1 or an
+    overflowing determinant would make the tool return nothing parseable at all.
+    They are sent as the matching strings instead, so the client gets a value it
+    can read. Finite floats are unchanged.
     """
     if isinstance(value, bool):
         return value                      # bool is an int subclass
     if isinstance(value, int):
         return str(value) if abs(value) > _EXACT_JSON_INT_LIMIT else value
+    if isinstance(value, float) and not math.isfinite(value):
+        if math.isnan(value):
+            return "NaN"
+        return "Infinity" if value > 0 else "-Infinity"
     if isinstance(value, dict):
         return {key: _exactify_large_ints(item) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
@@ -637,11 +651,63 @@ async def _evaluate_structured(
     monitoring.record_success(worker_result.elapsed_ms)
     if worker_result.result is None:
         return None
-    try:
-        parsed = ast.literal_eval(worker_result.result)
-    except Exception:
+    parsed = _reconstruct_result(worker_result.result)
+    if parsed is _UNRECONSTRUCTED:
         return worker_result.result
     return _exactify_large_ints(parsed)
+
+
+# Sentinel: the worker's result was not a reconstructable literal (a Sage object
+# repr, say), so the caller keeps the raw string.
+_UNRECONSTRUCTED = object()
+
+
+def _reconstruct_result(text: str):
+    """Rebuild the Python value a worker sent back as a ``repr`` string.
+
+    ``ast.literal_eval`` covers the finite case, but it rejects the bare tokens
+    ``inf`` and ``nan`` that ``repr`` emits for non-finite floats -- so a whole
+    dict like calculate_expression's ``{'string': ..., 'numeric': -inf}`` failed
+    to parse and fell back to being stringified, and the tool returned a garbled
+    double-encoded string instead of its fields. This falls back to a bounded
+    literal evaluator that additionally permits ``inf``/``nan`` at any depth.
+    Non-finite floats then reach ``_exactify_large_ints``, which turns them into
+    JSON-safe strings. It evaluates only literals, containers, unary +/- and the
+    two float names -- no calls, attributes or other names -- so it runs no code.
+    """
+    try:
+        return ast.literal_eval(text)
+    except Exception:
+        pass
+    try:
+        node = ast.parse(text, mode="eval").body
+    except SyntaxError:
+        return _UNRECONSTRUCTED
+    try:
+        return _eval_literal_allowing_non_finite(node)
+    except (ValueError, TypeError):
+        return _UNRECONSTRUCTED
+
+
+_NON_FINITE_NAMES = {"inf": math.inf, "nan": math.nan}
+
+
+def _eval_literal_allowing_non_finite(node: ast.AST):
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name) and node.id in _NON_FINITE_NAMES:
+        return _NON_FINITE_NAMES[node.id]
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.USub, ast.UAdd)):
+        operand = _eval_literal_allowing_non_finite(node.operand)
+        return -operand if isinstance(node.op, ast.USub) else +operand
+    if isinstance(node, ast.Dict):
+        return {
+            _eval_literal_allowing_non_finite(k): _eval_literal_allowing_non_finite(v)
+            for k, v in zip(node.keys, node.values, strict=True)
+        }
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return [_eval_literal_allowing_non_finite(e) for e in node.elts]
+    raise ValueError("not a permitted literal node")
 
 
 # A plain Python identifier. Variable names are interpolated into generated code

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -404,6 +404,72 @@ def test_integers_a_client_can_represent_are_left_as_numbers() -> None:
         assert isinstance(_exactify_large_ints(value), int)
 
 
+def test_non_finite_floats_become_strings() -> None:
+    """`Infinity`/`NaN` are not valid JSON; a strict client rejects the whole
+    response, so a quantile at p=1 or an overflowing determinant would return
+    nothing parseable. Send them as strings instead."""
+    import json
+
+    from sagemath_mcp.codegen import _exactify_large_ints
+
+    assert _exactify_large_ints(float("inf")) == "Infinity"
+    assert _exactify_large_ints(float("-inf")) == "-Infinity"
+    assert _exactify_large_ints(float("nan")) == "NaN"
+    # Recurses into the containers tools actually return.
+    safe = _exactify_large_ints({"a": [1.0, float("inf")], "b": float("nan")})
+    assert safe == {"a": [1.0, "Infinity"], "b": "NaN"}
+    # And the result is now valid JSON a client can parse.
+    json.loads(json.dumps(safe))  # would emit bare Infinity/NaN before the fix
+
+
+def test_finite_floats_are_left_untouched() -> None:
+    from sagemath_mcp.codegen import _exactify_large_ints
+
+    for value in (0.0, -1.5, 3.14, 1e300, -1e-300):
+        assert _exactify_large_ints(value) == value
+        assert isinstance(_exactify_large_ints(value), float)
+
+
+def test_reconstruct_result_restores_a_dict_with_a_non_finite_float() -> None:
+    """calculate_expression's shape: the whole dict used to collapse to a string
+    because `ast.literal_eval` rejects the `inf`/`nan` tokens in a repr."""
+    from sagemath_mcp.codegen import _exactify_large_ints, _reconstruct_result
+
+    parsed = _reconstruct_result("{'string': '-Infinity', 'numeric': -inf}")
+    assert parsed == {"string": "-Infinity", "numeric": float("-inf")}
+    # And after sanitising, the shape is preserved and JSON-safe.
+    safe = _exactify_large_ints(parsed)
+    assert safe == {"string": "-Infinity", "numeric": "-Infinity"}
+
+
+def test_reconstruct_result_handles_bare_and_nested_non_finite() -> None:
+    import math
+
+    from sagemath_mcp.codegen import _reconstruct_result
+
+    assert math.isnan(_reconstruct_result("nan"))
+    assert _reconstruct_result("[1.0, inf, nan]")[1] == float("inf")
+    assert _reconstruct_result("+inf") == float("inf")
+
+
+def test_reconstruct_result_keeps_a_non_literal_as_the_raw_string() -> None:
+    """A Sage object repr is not a literal; the caller keeps the string as-is."""
+    from sagemath_mcp.codegen import _UNRECONSTRUCTED, _reconstruct_result
+
+    # A name that is not inf/nan, and a call, are both refused -> sentinel.
+    assert _reconstruct_result("Rational(1, 2)") is _UNRECONSTRUCTED
+    assert _reconstruct_result("x + 1") is _UNRECONSTRUCTED
+    # Unparseable text is also handled.
+    assert _reconstruct_result("[1, 2") is _UNRECONSTRUCTED
+
+
+def test_reconstruct_result_still_parses_ordinary_finite_values() -> None:
+    from sagemath_mcp.codegen import _reconstruct_result
+
+    assert _reconstruct_result("{'a': 42, 'b': [1, 2.5]}") == {"a": 42, "b": [1, 2.5]}
+    assert _reconstruct_result("'just a string'") == "just a string"
+
+
 def test_exactify_reaches_inside_containers() -> None:
     """Results are often lists and dicts: factorisations, bases, varieties."""
     from sagemath_mcp.codegen import _exactify_large_ints

--- a/tests/test_math_examples.py
+++ b/tests/test_math_examples.py
@@ -534,3 +534,31 @@ async def test_plot3d_expression_renders_png(monkeypatch, label, expression):
         assert len(payload) > 1000, f"{label}: payload suspiciously small"
     finally:
         await manager.shutdown()
+
+
+@requires_sage
+@pytest.mark.asyncio
+async def test_non_finite_results_keep_their_shape_and_are_json_safe(monkeypatch):
+    """A tool result that is (or contains) a non-finite float must stay valid
+    JSON and keep its documented shape.
+
+    calculate_expression("log(0)") produces numeric = -inf. Its repr's `-inf`
+    token used to defeat the result reconstruction, so the whole {string,
+    numeric} dict collapsed to a single double-encoded `string` field -- and a
+    bare -inf would have been emitted as the invalid-JSON token `-Infinity`.
+    """
+    import json
+
+    settings = SageSettings(force_python_worker=False, eval_timeout=60.0)
+    manager = SageSessionManager(settings)
+    monkeypatch.setattr(runtime, "SESSION_MANAGER", manager)
+    ctx = FakeContext("non-finite")
+    try:
+        result = await server.calculate_expression("log(0)", ctx=ctx)
+        # Shape preserved: both fields present, not a single stringified blob.
+        assert set(result) == {"string", "numeric"}
+        assert result["numeric"] == "-Infinity"  # non-finite -> JSON-safe string
+        # The whole thing round-trips through a strict JSON parser.
+        json.loads(json.dumps(result))
+    finally:
+        await manager.shutdown()


### PR DESCRIPTION
The return-shape audit from the 2026-09-06 external evaluation — sweep every tool's return for values that are technically returned but break through an MCP client.

## Finding
Beyond the already-handled cases (large ints → decimal strings, plots → image content), one real class remained: **non-finite floats**.
- A `float('inf')`/`nan` serialises to the bare tokens `Infinity`/`NaN`, which are **not valid JSON** — a strict client's parser rejects the whole response.
- Worse, a result *containing* one defeated result reconstruction: `_evaluate_structured` rebuilds a worker's repr with `ast.literal_eval`, which rejects the `inf`/`nan` tokens, so `calculate_expression("log(0)")`'s `{string, numeric}` dict collapsed to a single **double-encoded string** — the documented `numeric` field vanished.

(A plain *string* result was never the problem — as noted in review, an LLM reads strings fine. The issues are specifically *unparseable JSON* and a *broken shape*.)

## Fix
Both at the one point every helper tool's result passes:
- Reconstruction falls back to a **bounded literal evaluator** that permits `inf`/`nan` at any depth — literals, containers, unary `+/-` and those two float names only, no calls/attributes/other names, so it runs no code.
- `_exactify_large_ints` sends non-finite floats as the strings `Infinity`/`-Infinity`/`NaN`, the way it already sends oversized ints as strings.

## Verification
Real SageMath 10.9: `calculate_expression("log(0)")` now returns `{"string": "-Infinity", "numeric": "-Infinity"}` (shape preserved, JSON-strict). Integration green (1145 passed), 100% coverage. `tests/test_codegen.py` + a real-Sage regression in `tests/test_math_examples.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)