### PR TITLE
Add outcome benchmark: reasoning-only vs. Sage compute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ here is a breaking change.
 
 ### Added
 
+- **Outcome benchmark.** `benchmarks/` — a fixed, seeded case set (`cases.json`,
+  24 problems in five difficulty tiers, every gold answer verified in the Sage
+  10.9 container) and a Workflow (`outcome_benchmark.workflow.js`) that runs it
+  through the model twice, reasoning-only vs. with Sage compute, scoring every
+  answer for *mathematical equivalence* in Sage (not string-matched) by an
+  independent step. It measures the claim the doctest corpus cannot: do models
+  get more mathematics *right* with these tools. First run (subject `haiku`,
+  judge `sonnet`, `scripts/write_benchmark_stats.py` → `benchmark-stats.md`):
+  **17/24 → 24/24**, the entire +7 in the compute-heavy and infeasible tiers —
+  a factoring, an 8×8 determinant, a partition count — where reasoning alone
+  refused six and answered one *confidently wrong*, while Sage got all ten. On
+  the arithmetic/competition/advanced tiers both arms score 100%: the tool does
+  not help where the model is already right, and does not hurt. A stronger
+  subject model closes the gap on its own — this is as much a measurement of the
+  model as of the server, so it is never CI-gated.
 - **MCP prompts (3).** `prove_and_verify`, `solve_and_check` and
   `explore_object` — reusable instructions a client surfaces in its prompt
   picker, each steering the model toward what this server is good at: verifying

--- a/README.md
+++ b/README.md
@@ -1261,6 +1261,23 @@ uv run python scripts/run_mutation_tests.py --workers 1  # serial reference
 
 Each worker mutates its own copy of the tree with `PYTHONPATH` shadowing the editable install, turning a ~35-minute serial sweep into ~2 minutes. The result is written to `mutation-stats.md`; a weekly, non-gating CI job (`.github/workflows/mutation.yml`) regenerates and uploads it. The Hypothesis property tests in `tests/test_security_property.py` — every forbidden name in every referencing position, any attribute on any forbidden module, any import at all — are what kill the behavioural mutants. This is never a required check: the score measures test *quality*, not correctness, and `allowlist.py` is out of scope because it is generated data guarded by the Sage-agreement integration test.
 
+### Outcome benchmark
+
+The doctest corpus sweep proves the guardrails do not *refuse* mathematics. This is the other claim: does a model get more mathematics *right* when it can run Sage? `benchmarks/` holds a fixed, seeded case set (`cases.json`, 24 problems in five difficulty tiers, every gold answer verified in the Sage container) and a Workflow (`outcome_benchmark.workflow.js`) that runs it through the model twice — reasoning alone vs. with Sage compute — scoring every answer for *mathematical equivalence* in Sage, by an independent step, never string-matched.
+
+First run (subject model `haiku`, scoring judge `sonnet`, full detail in [`benchmark-stats.md`](benchmark-stats.md)):
+
+| Tier | Reasoning only | With Sage |
+| --- | ---: | ---: |
+| arithmetic (GSM8K-style) | 4/4 | 4/4 |
+| competition (MATH-style) | 5/5 | 5/5 |
+| advanced (CAS-suited) | 5/5 | 5/5 |
+| compute-heavy | 3/5 | 5/5 |
+| infeasible (factoring, 8×8 det, partitions) | 0/5 | 5/5 |
+| **Total** | **17/24 (71%)** | **24/24 (100%)** |
+
+The lift is entirely in the last two tiers — arbitrary computation a model cannot do in-context — where reasoning alone refused six problems and answered one *confidently wrong* (the failure mode [`verify_claim`](#verify_claim) exists for), while Sage got all ten. On problems the model already handles, the tool changes nothing: it does not help where it is not needed, and does not hurt. A stronger subject model closes the gap on its own, so this measures the model as much as the server; it is never CI-gated. The rigorous three-arm version (no-tools / `evaluate_sage`-only / full-catalogue, with real tool-gating) runs under the CLI nightlies.
+
 ### Linting
 
 Ruff with line-length 100, target Python 3.12. Rules: E, F, W, B, UP, ASYNC, RUF, I (import sorting). Run `make lint` before committing.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -198,17 +198,21 @@ documentation rather than surface:
       counterexample can no longer fall outside a stated domain (`x != 1/2` under
       `assume(x, 'integer')` is not refuted at 1/2). Assumptions are named in the
       evidence of any verdict that relied on them.
-- [ ] **Outcome benchmarks.** Axiom publishes GSM8K / MATH accuracy deltas;
-      this project's doctest corpus sweep proves the guardrails do not refuse
-      mathematics, which is a different claim from "models get more answers
-      right with these tools". The machinery is already here:
-      `tests/cli_integration` drives Claude, Gemini and Codex against the live
-      server with per-case validation. Add a benchmark case set (a fixed-seed
-      subset of the MIT-licensed GSM8K and MATH datasets) and a no-tools control
-      mode in the runner, emit the with/without scores to a stats file the way
-      the corpus sweep writes `doctest-corpus-stats.md`, and publish the deltas
-      in the README. Runs where the CLI nightlies run — never CI-gated, because
-      the number measures the client model as much as the server.
+- [x] **Outcome benchmarks.** *Done, 2026-09-07.* `benchmarks/` — a fixed,
+      seeded case set (`cases.json`, 24 problems across five difficulty tiers,
+      every gold answer verified in the Sage container) and a Workflow
+      (`outcome_benchmark.workflow.js`) that runs it through the model twice,
+      reasoning-only vs. with Sage compute, and scores every answer for
+      mathematical equivalence in Sage by an independent step. Published to
+      `benchmark-stats.md` and the README the way the corpus sweep writes
+      `doctest-corpus-stats.md`. First run (subject `haiku`): **17/24 → 24/24**,
+      the whole +7 in the compute-heavy/infeasible tiers, including one
+      reasoning-only answer that was *confidently wrong* — the failure mode the
+      server addresses. Never CI-gated: the number measures the model as much as
+      the server. Follow-up remains to fold the fixed case set + a no-tools
+      control into `tests/cli_integration` for the rigorous three-arm
+      (no-tools / `evaluate_sage`-only / full-catalogue) version under the CLI
+      nightlies, where real tool-gating and per-client keys live.
 - [ ] **Passagemath runtime for install footprint.** "Where this project is
       behind" item 4 above. **Evaluated 2026-09-06**
       ([docs/passagemath_evaluation.md](docs/passagemath_evaluation.md), verified

--- a/TODO.md
+++ b/TODO.md
@@ -59,12 +59,16 @@ out of date.
         description; the fresh-namespace exception now sits in the tool
         description the model reads and at the top of the `evaluate_sage`
         reference, not only in the deep session-semantics note.
-- [ ] From the 2026-08-24 field survey, one feature remains (roadmap has the
-      mechanism): outcome benchmarks (GSM8K/MATH deltas) via the existing CLI
-      harness — per the 2026-09-06 review, compare no-tools vs `evaluate_sage`
-      only vs the full catalogue, include iterative advanced mathematics beyond
-      GSM8K/MATH, and measure wrong-confident answers, refusals, recovery,
-      latency and tool-call count. `verify_claim` shipped 2026-09-06
+- [x] From the 2026-08-24 field survey: outcome benchmarks. *Done, 2026-09-07.*
+      `benchmarks/` (fixed seeded case set + Workflow, scored for equivalence in
+      Sage); first run subject `haiku` = **17/24 → 24/24 with Sage**, +7 all in
+      the compute-heavy/infeasible tiers, one reasoning-only answer confidently
+      wrong. Published to `benchmark-stats.md` + README. This is the live 2-arm
+      (reasoning vs. Sage compute) version; the rigorous three-arm (no-tools vs
+      `evaluate_sage`-only vs full catalogue, with real tool-gating and the
+      wrong-confident/refusal/latency/tool-call breakdown per the 2026-09-06
+      review) still wants folding into the `tests/cli_integration` nightlies,
+      where the per-client keys live. `verify_claim` shipped 2026-09-06
       (`tools/verify.py`).
 - [ ] Passagemath runtime extra to cut install footprint. Evaluated 2026-09-06
       (`docs/passagemath_evaluation.md`): verdict **adopt, pinned to a verified

--- a/benchmark-stats.md
+++ b/benchmark-stats.md
@@ -1,0 +1,80 @@
+# Outcome benchmark
+
+Does the model get more mathematics right when it can run Sage, versus
+reasoning alone? Two arms over the fixed case set in `benchmarks/cases.json`,
+every answer scored for *mathematical equivalence* in the SageMath 10.9
+container (not string-matched). Produced by
+`benchmarks/outcome_benchmark.workflow.js`.
+
+- Generated: 2026-09-07
+- Cases: 24 across tiers: arithmetic, competition, advanced, compute-heavy, infeasible
+- Subject model (under test): `haiku`; scoring judge: `sonnet`
+- This is as much a measurement of the subject model as of the server; a
+  stronger model closes the gap on its own. Never CI-gated.
+
+## Headline
+
+| Arm | Correct | Wrong-confident | Refused | Sage calls |
+| --- | ---: | ---: | ---: | ---: |
+| Reasoning only | 17/24 (71%) | 1 | 6 | 0 |
+| With Sage compute | 24/24 (100%) | 0 | 0 | 37 |
+
+**Delta: +7** answers correct with Sage compute (17/24 (71%) → 24/24 (100%)).
+
+## By tier
+
+| Tier | Reasoning only | With Sage | Delta |
+| --- | ---: | ---: | ---: |
+| arithmetic | 4/4 (100%) | 4/4 (100%) | 0 |
+| competition | 5/5 (100%) | 5/5 (100%) | 0 |
+| advanced | 5/5 (100%) | 5/5 (100%) | 0 |
+| compute-heavy | 3/5 (60%) | 5/5 (100%) | +2 |
+| infeasible | 0/5 (0%) | 5/5 (100%) | +5 |
+
+## Per problem
+
+A ✗ in *Reasoning only* that is ✓ *With Sage* is the value the server adds;
+a wrong-confident cell (⚠) is the failure mode `verify_claim` exists for.
+
+| ID | Tier | Reasoning only | With Sage |
+| --- | --- | :---: | :---: |
+| A1 | arithmetic | ✓ | ✓ |
+| A2 | arithmetic | ✓ | ✓ |
+| A3 | arithmetic | ✓ | ✓ |
+| A4 | arithmetic | ✓ | ✓ |
+| B1 | competition | ✓ | ✓ |
+| B2 | competition | ✓ | ✓ |
+| B3 | competition | ✓ | ✓ |
+| B4 | competition | ✓ | ✓ |
+| B5 | competition | ✓ | ✓ |
+| C1 | advanced | ✓ | ✓ |
+| C2 | advanced | ✓ | ✓ |
+| C3 | advanced | ✓ | ✓ |
+| C4 | advanced | ✓ | ✓ |
+| C5 | advanced | ✓ | ✓ |
+| D1 | compute-heavy | ✓ | ✓ |
+| D2 | compute-heavy | ✓ | ✓ |
+| D3 | compute-heavy | ⚠ wrong | ✓ |
+| D4 | compute-heavy | — (refused) | ✓ |
+| D5 | compute-heavy | ✓ | ✓ |
+| E1 | infeasible | — (refused) | ✓ |
+| E2 | infeasible | — (refused) | ✓ |
+| E3 | infeasible | — (refused) | ✓ |
+| E4 | infeasible | — (refused) | ✓ |
+| E5 | infeasible | — (refused) | ✓ |
+
+## Method and honest limits
+
+- The two arms are the **same model**; one is told to reason unaided, the
+  other to compute and verify with Sage. The delta is the lift from having
+  the CAS in the loop.
+- *Reasoning only* is **prompt-enforced**: the agent is told not to execute
+  anything and self-reports zero tool calls. It is not hard tool-gated. The
+  rigorous three-arm version (no-tools / `evaluate_sage`-only / full
+  catalogue, with real gating) is the `tests/cli_integration` harness, which
+  runs under the CLI nightlies with API keys.
+- Answers are scored by an **independent** Sage-backed step, so a plausible
+  wrong answer is caught, not accepted on its wording.
+- Small, fixed, seeded case set: this is a directional signal a run can
+  reproduce, not a leaderboard number. Grow `benchmarks/cases.json` to
+  tighten it.

--- a/benchmarks/cases.json
+++ b/benchmarks/cases.json
@@ -1,0 +1,198 @@
+{
+  "description": "Fixed outcome-benchmark case set for the SageMath MCP server. Each case has a verified ground-truth answer (computed in the SageMath 10.9 container). Difficulty tiers: A = grade-school arithmetic (GSM8K-style), B = competition mathematics (MATH-style), C = advanced problems a CAS is built for. Answers are checked for mathematical equivalence in Sage, not string-matched.",
+  "seed": 20260907,
+  "cases": [
+    {
+      "id": "A1",
+      "tier": "arithmetic",
+      "problem": "A store sells pencils at 3 for $1.20. What is the cost, in dollars, of 17 pencils?",
+      "gold": "6.80",
+      "gold_sage": "34/5",
+      "check": "numeric"
+    },
+    {
+      "id": "A2",
+      "tier": "arithmetic",
+      "problem": "Maria reads 24 pages a day for 5 days, then 31 pages a day for 3 days. How many pages does she read in total?",
+      "gold": "213",
+      "gold_sage": "213",
+      "check": "numeric"
+    },
+    {
+      "id": "A3",
+      "tier": "arithmetic",
+      "problem": "A tank holds 480 liters. It is currently 5/8 full. If 90 liters are added, how many liters are in the tank?",
+      "gold": "390",
+      "gold_sage": "390",
+      "check": "numeric"
+    },
+    {
+      "id": "A4",
+      "tier": "arithmetic",
+      "problem": "Tom's age is 4 years more than twice Sam's age. If Tom is 34, how old is Sam?",
+      "gold": "15",
+      "gold_sage": "15",
+      "check": "numeric"
+    },
+    {
+      "id": "B1",
+      "tier": "competition",
+      "problem": "Find the sum of all positive divisors of 360.",
+      "gold": "1170",
+      "gold_sage": "1170",
+      "check": "numeric"
+    },
+    {
+      "id": "B2",
+      "tier": "competition",
+      "problem": "What is the remainder when 7^100 is divided by 13?",
+      "gold": "9",
+      "gold_sage": "9",
+      "check": "numeric"
+    },
+    {
+      "id": "B3",
+      "tier": "competition",
+      "problem": "Find the coefficient of x^7 in the expansion of (1 + x)^12.",
+      "gold": "792",
+      "gold_sage": "792",
+      "check": "numeric"
+    },
+    {
+      "id": "B4",
+      "tier": "competition",
+      "problem": "Evaluate the definite integral of x^2 * e^x from x = 0 to x = 1.",
+      "gold": "e - 2",
+      "gold_sage": "e - 2",
+      "check": "symbolic"
+    },
+    {
+      "id": "B5",
+      "tier": "competition",
+      "problem": "How many integers from 1 to 1000 inclusive are divisible by 6 or 10 but not by 15?",
+      "gold": "200",
+      "gold_sage": "200",
+      "check": "numeric"
+    },
+    {
+      "id": "C1",
+      "tier": "advanced",
+      "problem": "Find all eigenvalues of the matrix [[2, 1, 0], [1, 2, 1], [0, 1, 2]].",
+      "gold": "2, 2 - sqrt(2), 2 + sqrt(2)",
+      "gold_sage": "{2, 2 - sqrt(2), 2 + sqrt(2)}",
+      "check": "set"
+    },
+    {
+      "id": "C2",
+      "tier": "advanced",
+      "problem": "Evaluate the infinite sum of 1/n^4 for n from 1 to infinity.",
+      "gold": "pi^4/90",
+      "gold_sage": "pi^4/90",
+      "check": "symbolic"
+    },
+    {
+      "id": "C3",
+      "tier": "advanced",
+      "problem": "Factor x^4 - 5x^2 + 4 completely over the integers.",
+      "gold": "(x - 1)(x + 1)(x - 2)(x + 2)",
+      "gold_sage": "(x - 1)*(x + 1)*(x - 2)*(x + 2)",
+      "check": "symbolic"
+    },
+    {
+      "id": "C4",
+      "tier": "advanced",
+      "problem": "How many prime numbers are less than 10000?",
+      "gold": "1229",
+      "gold_sage": "1229",
+      "check": "numeric"
+    },
+    {
+      "id": "C5",
+      "tier": "advanced",
+      "problem": "Real numbers x, y, z satisfy x + y + z = 6, x^2 + y^2 + z^2 = 14, and x^3 + y^3 + z^3 = 36. Find the set {x, y, z}.",
+      "gold": "{1, 2, 3}",
+      "gold_sage": "{1, 2, 3}",
+      "check": "set"
+    },
+    {
+      "id": "D1",
+      "tier": "compute-heavy",
+      "problem": "How many integer partitions does the number 100 have?",
+      "gold": "190569292",
+      "gold_sage": "190569292",
+      "check": "numeric"
+    },
+    {
+      "id": "D2",
+      "tier": "compute-heavy",
+      "problem": "What is the sum of the decimal digits of 50! (50 factorial)?",
+      "gold": "216",
+      "gold_sage": "216",
+      "check": "numeric"
+    },
+    {
+      "id": "D3",
+      "tier": "compute-heavy",
+      "problem": "Compute the last 6 digits of 17^256, that is, 17^256 mod 1000000.",
+      "gold": "263681",
+      "gold_sage": "263681",
+      "check": "numeric"
+    },
+    {
+      "id": "D4",
+      "tier": "compute-heavy",
+      "problem": "Find the determinant of the integer matrix [[2,3,1,5,4],[1,4,2,3,6],[3,1,5,2,1],[4,2,3,6,2],[5,3,2,1,7]].",
+      "gold": "-23",
+      "gold_sage": "-23",
+      "check": "numeric"
+    },
+    {
+      "id": "D5",
+      "tier": "compute-heavy",
+      "problem": "What is the smallest prime number strictly greater than 10^12 (one trillion)?",
+      "gold": "1000000000039",
+      "gold_sage": "1000000000039",
+      "check": "numeric"
+    },
+    {
+      "id": "E1",
+      "tier": "infeasible",
+      "problem": "The number 121932631184363663946431 is a product of exactly two prime numbers. Find both prime factors.",
+      "gold": "123456789059 and 987654321109",
+      "gold_sage": "{123456789059, 987654321109}",
+      "check": "set"
+    },
+    {
+      "id": "E2",
+      "tier": "infeasible",
+      "problem": "Find the determinant of the 8x8 integer matrix with rows [9,-8,-3,-4,6,-4,7,-5], [3,-2,-2,3,8,7,-1,3], [7,-9,0,-2,-3,-8,-8,-6], [-4,-4,-4,-7,7,6,-3,-2], [6,6,-9,5,-2,-4,-1,-8], [7,1,8,-4,9,-8,-4,1], [-3,-6,-4,8,2,8,4,-6], [1,-6,-7,5,9,-5,0,1].",
+      "gold": "743706805",
+      "gold_sage": "743706805",
+      "check": "numeric"
+    },
+    {
+      "id": "E3",
+      "tier": "infeasible",
+      "problem": "How many integer partitions does the number 500 have?",
+      "gold": "2300165032574323995027",
+      "gold_sage": "2300165032574323995027",
+      "check": "numeric"
+    },
+    {
+      "id": "E4",
+      "tier": "infeasible",
+      "problem": "What is the 123456th prime number?",
+      "gold": "1632899",
+      "gold_sage": "1632899",
+      "check": "numeric"
+    },
+    {
+      "id": "E5",
+      "tier": "infeasible",
+      "problem": "Compute 123456789^987654321 mod 1000000007.",
+      "gold": "652541198",
+      "gold_sage": "652541198",
+      "check": "numeric"
+    }
+  ]
+}

--- a/benchmarks/latest_result.json
+++ b/benchmarks/latest_result.json
@@ -1,0 +1,645 @@
+{
+ "tiers": [
+  "arithmetic",
+  "competition",
+  "advanced",
+  "compute-heavy",
+  "infeasible"
+ ],
+ "arms": [
+  "no_tools",
+  "sage"
+ ],
+ "subjectModel": "haiku",
+ "judgeModel": "sonnet",
+ "perProblem": [
+  {
+   "id": "A1",
+   "tier": "arithmetic",
+   "arm": "no_tools",
+   "answer": "6.80",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "A2",
+   "tier": "arithmetic",
+   "arm": "no_tools",
+   "answer": "213",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "A3",
+   "tier": "arithmetic",
+   "arm": "no_tools",
+   "answer": "390",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "A4",
+   "tier": "arithmetic",
+   "arm": "no_tools",
+   "answer": "15",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "A1",
+   "tier": "arithmetic",
+   "arm": "sage",
+   "answer": "34/5",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "A2",
+   "tier": "arithmetic",
+   "arm": "sage",
+   "answer": "213",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "A3",
+   "tier": "arithmetic",
+   "arm": "sage",
+   "answer": "390",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "A4",
+   "tier": "arithmetic",
+   "arm": "sage",
+   "answer": "15",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "B1",
+   "tier": "competition",
+   "arm": "no_tools",
+   "answer": "1170",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "B2",
+   "tier": "competition",
+   "arm": "no_tools",
+   "answer": "9",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "B3",
+   "tier": "competition",
+   "arm": "no_tools",
+   "answer": "792",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "B4",
+   "tier": "competition",
+   "arm": "no_tools",
+   "answer": "e - 2",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "B5",
+   "tier": "competition",
+   "arm": "no_tools",
+   "answer": "200",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "B1",
+   "tier": "competition",
+   "arm": "sage",
+   "answer": "1170",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "B2",
+   "tier": "competition",
+   "arm": "sage",
+   "answer": "9",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "B3",
+   "tier": "competition",
+   "arm": "sage",
+   "answer": "792",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "B4",
+   "tier": "competition",
+   "arm": "sage",
+   "answer": "e - 2",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "B5",
+   "tier": "competition",
+   "arm": "sage",
+   "answer": "200",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "C1",
+   "tier": "advanced",
+   "arm": "no_tools",
+   "answer": "{2, 2-\u221a2, 2+\u221a2}",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "C2",
+   "tier": "advanced",
+   "arm": "no_tools",
+   "answer": "\u03c0\u2074/90",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "C3",
+   "tier": "advanced",
+   "arm": "no_tools",
+   "answer": "(x-2)(x-1)(x+1)(x+2)",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "C4",
+   "tier": "advanced",
+   "arm": "no_tools",
+   "answer": "1229",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "C5",
+   "tier": "advanced",
+   "arm": "no_tools",
+   "answer": "{1, 2, 3}",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "C1",
+   "tier": "advanced",
+   "arm": "sage",
+   "answer": "[2, 2 - sqrt(2), 2 + sqrt(2)]",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 3,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "C2",
+   "tier": "advanced",
+   "arm": "sage",
+   "answer": "pi^4/90",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "C3",
+   "tier": "advanced",
+   "arm": "sage",
+   "answer": "(x - 2)*(x - 1)*(x + 1)*(x + 2)",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "C4",
+   "tier": "advanced",
+   "arm": "sage",
+   "answer": "1229",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "C5",
+   "tier": "advanced",
+   "arm": "sage",
+   "answer": "{1, 2, 3}",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 2,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "D1",
+   "tier": "compute-heavy",
+   "arm": "no_tools",
+   "answer": "190569292",
+   "refused": false,
+   "confident": false,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "D2",
+   "tier": "compute-heavy",
+   "arm": "no_tools",
+   "answer": "216",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "D3",
+   "tier": "compute-heavy",
+   "arm": "no_tools",
+   "answer": "463681",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 0,
+   "correct": false,
+   "wrong_confident": true
+  },
+  {
+   "id": "D4",
+   "tier": "compute-heavy",
+   "arm": "no_tools",
+   "answer": "",
+   "refused": true,
+   "confident": false,
+   "tool_calls": 0,
+   "correct": false,
+   "wrong_confident": false
+  },
+  {
+   "id": "D5",
+   "tier": "compute-heavy",
+   "arm": "no_tools",
+   "answer": "1000000000039",
+   "refused": false,
+   "confident": false,
+   "tool_calls": 0,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "D1",
+   "tier": "compute-heavy",
+   "arm": "sage",
+   "answer": "190569292",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 2,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "D2",
+   "tier": "compute-heavy",
+   "arm": "sage",
+   "answer": "216",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 2,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "D3",
+   "tier": "compute-heavy",
+   "arm": "sage",
+   "answer": "263681",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 2,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "D4",
+   "tier": "compute-heavy",
+   "arm": "sage",
+   "answer": "-23",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 1,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "D5",
+   "tier": "compute-heavy",
+   "arm": "sage",
+   "answer": "1000000000039",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 2,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "E1",
+   "tier": "infeasible",
+   "arm": "no_tools",
+   "answer": "",
+   "refused": true,
+   "confident": false,
+   "tool_calls": 0,
+   "correct": false,
+   "wrong_confident": false
+  },
+  {
+   "id": "E2",
+   "tier": "infeasible",
+   "arm": "no_tools",
+   "answer": "",
+   "refused": true,
+   "confident": false,
+   "tool_calls": 0,
+   "correct": false,
+   "wrong_confident": false
+  },
+  {
+   "id": "E3",
+   "tier": "infeasible",
+   "arm": "no_tools",
+   "answer": "",
+   "refused": true,
+   "confident": false,
+   "tool_calls": 0,
+   "correct": false,
+   "wrong_confident": false
+  },
+  {
+   "id": "E4",
+   "tier": "infeasible",
+   "arm": "no_tools",
+   "answer": "",
+   "refused": true,
+   "confident": false,
+   "tool_calls": 0,
+   "correct": false,
+   "wrong_confident": false
+  },
+  {
+   "id": "E5",
+   "tier": "infeasible",
+   "arm": "no_tools",
+   "answer": "",
+   "refused": true,
+   "confident": false,
+   "tool_calls": 0,
+   "correct": false,
+   "wrong_confident": false
+  },
+  {
+   "id": "E1",
+   "tier": "infeasible",
+   "arm": "sage",
+   "answer": "123456789059 * 987654321109",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 2,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "E2",
+   "tier": "infeasible",
+   "arm": "sage",
+   "answer": "743706805",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 2,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "E3",
+   "tier": "infeasible",
+   "arm": "sage",
+   "answer": "2300165032574323995027",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 3,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "E4",
+   "tier": "infeasible",
+   "arm": "sage",
+   "answer": "1632899",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 2,
+   "correct": true,
+   "wrong_confident": false
+  },
+  {
+   "id": "E5",
+   "tier": "infeasible",
+   "arm": "sage",
+   "answer": "652541198",
+   "refused": false,
+   "confident": true,
+   "tool_calls": 2,
+   "correct": true,
+   "wrong_confident": false
+  }
+ ],
+ "summary": {
+  "overall": {
+   "no_tools": {
+    "total": 24,
+    "correct": 17,
+    "refused": 6,
+    "wrongConfident": 1,
+    "toolCalls": 0
+   },
+   "sage": {
+    "total": 24,
+    "correct": 24,
+    "refused": 0,
+    "wrongConfident": 0,
+    "toolCalls": 37
+   }
+  },
+  "byTier": {
+   "arithmetic": {
+    "no_tools": {
+     "total": 4,
+     "correct": 4,
+     "refused": 0,
+     "wrongConfident": 0,
+     "toolCalls": 0
+    },
+    "sage": {
+     "total": 4,
+     "correct": 4,
+     "refused": 0,
+     "wrongConfident": 0,
+     "toolCalls": 4
+    }
+   },
+   "competition": {
+    "no_tools": {
+     "total": 5,
+     "correct": 5,
+     "refused": 0,
+     "wrongConfident": 0,
+     "toolCalls": 0
+    },
+    "sage": {
+     "total": 5,
+     "correct": 5,
+     "refused": 0,
+     "wrongConfident": 0,
+     "toolCalls": 5
+    }
+   },
+   "advanced": {
+    "no_tools": {
+     "total": 5,
+     "correct": 5,
+     "refused": 0,
+     "wrongConfident": 0,
+     "toolCalls": 0
+    },
+    "sage": {
+     "total": 5,
+     "correct": 5,
+     "refused": 0,
+     "wrongConfident": 0,
+     "toolCalls": 8
+    }
+   },
+   "compute-heavy": {
+    "no_tools": {
+     "total": 5,
+     "correct": 3,
+     "refused": 1,
+     "wrongConfident": 1,
+     "toolCalls": 0
+    },
+    "sage": {
+     "total": 5,
+     "correct": 5,
+     "refused": 0,
+     "wrongConfident": 0,
+     "toolCalls": 9
+    }
+   },
+   "infeasible": {
+    "no_tools": {
+     "total": 5,
+     "correct": 0,
+     "refused": 5,
+     "wrongConfident": 0,
+     "toolCalls": 0
+    },
+    "sage": {
+     "total": 5,
+     "correct": 5,
+     "refused": 0,
+     "wrongConfident": 0,
+     "toolCalls": 11
+    }
+   }
+  }
+ }
+}

--- a/benchmarks/outcome_benchmark.workflow.js
+++ b/benchmarks/outcome_benchmark.workflow.js
@@ -1,0 +1,221 @@
+// Outcome benchmark for the SageMath MCP server.
+//
+// Measures the core credibility claim the roadmap asks for: does the model get
+// more mathematics right when it can run Sage, versus reasoning alone? Two arms
+// over a fixed case set (benchmarks/cases.json):
+//   - no_tools : the model must answer by reasoning only, no execution.
+//   - sage     : the model may run Sage (docker exec sage-mcp) to compute/verify.
+// Each cohort's answers are then scored INDEPENDENTLY for mathematical
+// equivalence in the same Sage, never string-matched.
+//
+// Run:  Workflow({ scriptPath: "benchmarks/outcome_benchmark.workflow.js",
+//                  args: <parsed cases.json> })
+// The case set is passed in as `args` so the script has a fixed, seeded input.
+//
+// Honest limitation: "no_tools" is prompt-enforced (the subagent is told not to
+// execute anything and self-reports zero tool calls), not hard tool-gated. The
+// rigorous 3-arm version -- no-tools / evaluate_sage-only / full-catalogue with
+// real tool gating -- is the tests/cli_integration harness, which runs under the
+// CLI nightlies with API keys. This measures the model in the loop as much as
+// the server, and is never CI-gated.
+
+export const meta = {
+  name: 'outcome-benchmark',
+  description: 'Measure the math-accuracy delta from Sage compute vs reasoning alone on a fixed case set',
+  phases: [
+    { title: 'Solve', detail: 'each (tier, arm) cohort solves its problems' },
+    { title: 'Score', detail: 'check every answer for equivalence in Sage' },
+  ],
+}
+
+const cases = args.cases
+const tiers = [...new Set(cases.map((c) => c.tier))]
+const arms = ['no_tools', 'sage']
+
+// The subject under test is a fast, lower-tier model on purpose: a frontier
+// model solves this whole set unaided (zero delta), so it cannot show what the
+// tool adds. Both arms use the SAME subject -- the only variable is Sage access.
+// Scoring is a separate concern (reliable equivalence-checking), so the judge is
+// a step up. Override via args.subjectModel / args.judgeModel.
+const SUBJECT_MODEL = args.subjectModel || 'haiku'
+const JUDGE_MODEL = args.judgeModel || 'sonnet'
+
+const SOLVE_SCHEMA = {
+  type: 'object',
+  properties: {
+    answers: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          answer: { type: 'string' },
+          refused: { type: 'boolean' },
+          confident: { type: 'boolean' },
+          tool_calls: { type: 'integer' },
+        },
+        required: ['id', 'answer', 'refused', 'confident', 'tool_calls'],
+      },
+    },
+  },
+  required: ['answers'],
+}
+
+const SCORE_SCHEMA = {
+  type: 'object',
+  properties: {
+    verdicts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          correct: { type: 'boolean' },
+          note: { type: 'string' },
+        },
+        required: ['id', 'correct'],
+      },
+    },
+  },
+  required: ['verdicts'],
+}
+
+function solvePrompt(tierCases, arm) {
+  const probs = tierCases.map((c) => `[${c.id}] ${c.problem}`).join('\n')
+  if (arm === 'no_tools') {
+    return (
+      'You are being evaluated on UNAIDED mathematical ability. Solve each ' +
+      'problem by reasoning and hand computation ONLY. Do NOT run any command, ' +
+      'script, calculator, or computer-algebra system -- no Bash, no code ' +
+      'execution of any kind, no docker. Work each out yourself.\n\n' +
+      `Problems:\n${probs}\n\n` +
+      'Return one entry per problem: id, answer (the FINAL answer only, as a ' +
+      'plain mathematical expression -- e.g. "213", "e - 2", ' +
+      '"{2, 2-sqrt(2), 2+sqrt(2)}"), refused (true only if you truly cannot ' +
+      'produce any answer), confident (true if you believe it is correct), ' +
+      'tool_calls (0 -- you must not execute anything in this arm).'
+    )
+  }
+  return (
+    'You are solving mathematics problems and you HAVE a SageMath CAS. Run it ' +
+    "with:  docker exec sage-mcp sage -c '<sage code>'  (print the result). Use " +
+    'it to compute AND to verify every answer; prefer exact results.\n\n' +
+    `Problems:\n${probs}\n\n` +
+    'Return one entry per problem: id, answer (the FINAL answer only, as a ' +
+    'plain mathematical expression matching Sage form -- e.g. "34/5", "e - 2", ' +
+    '"{2, 2-sqrt(2), 2+sqrt(2)}"), refused (true only if you cannot produce ' +
+    'any answer), confident (true if you verified it in Sage), tool_calls (how ' +
+    'many times you invoked Sage for that problem).'
+  )
+}
+
+function scorePrompt(tierCases, solved) {
+  const answers = (solved && solved.answers) || []
+  const rows = tierCases
+    .map((c) => {
+      const a = answers.find((x) => x.id === c.id) || { answer: '(no answer)', refused: true }
+      return (
+        `[${c.id}] problem: ${c.problem}\n` +
+        `  gold (Sage form): ${c.gold_sage}   check-type: ${c.check}\n` +
+        `  model answer: ${a.answer}`
+      )
+    })
+    .join('\n')
+  return (
+    'Score each model answer for MATHEMATICAL EQUIVALENCE to the gold, using ' +
+    "SageMath. Run checks with:  docker exec sage-mcp sage -c '<code>'  and print " +
+    'a clear True/False. Be strict -- numerically close but not equal is WRONG.\n\n' +
+    'Rules by check-type:\n' +
+    '- numeric: correct iff bool(SR(model) == SR(gold)) is True (exact ' +
+    'rational/integer equality; parse the model answer, strip $ and commas).\n' +
+    '- symbolic: correct iff bool((SR(model) - SR(gold)).simplify_full() == 0).\n' +
+    '- set: parse both as sets; correct iff equal as sets (compare exact ' +
+    'symbolic values, or sorted high-precision numerics element-wise).\n' +
+    '- A missing, unparseable, or refused answer is NOT correct.\n\n' +
+    'Return one verdict per problem: id, correct (bool), note (the Sage check ' +
+    'you ran and its True/False result).\n\n' +
+    rows
+  )
+}
+
+phase('Solve')
+const cohorts = tiers.flatMap((t) => arms.map((arm) => ({ t, arm })))
+
+const results = await pipeline(
+  cohorts,
+  ({ t, arm }) => {
+    const tc = cases.filter((c) => c.tier === t)
+    return agent(solvePrompt(tc, arm), {
+      label: `solve:${t}:${arm}`,
+      phase: 'Solve',
+      schema: SOLVE_SCHEMA,
+      agentType: 'general-purpose',
+      model: SUBJECT_MODEL,
+      effort: 'low',
+    }).then((sol) => ({ t, arm, sol }))
+  },
+  ({ t, arm, sol }) => {
+    const tc = cases.filter((c) => c.tier === t)
+    if (!sol) return { t, arm, sol: null, sc: null }
+    return agent(scorePrompt(tc, sol), {
+      label: `score:${t}:${arm}`,
+      phase: 'Score',
+      schema: SCORE_SCHEMA,
+      agentType: 'general-purpose',
+      model: JUDGE_MODEL,
+    }).then((sc) => ({ t, arm, sol, sc }))
+  },
+)
+
+// --- aggregate ---
+const perProblem = []
+for (const r of results.filter(Boolean)) {
+  const { t, arm, sol, sc } = r
+  const answers = (sol && sol.answers) || []
+  const verdicts = (sc && sc.verdicts) || []
+  for (const c of cases.filter((x) => x.tier === t)) {
+    const a = answers.find((x) => x.id === c.id) || {
+      answer: null,
+      refused: true,
+      confident: false,
+      tool_calls: 0,
+    }
+    const v = verdicts.find((x) => x.id === c.id) || { correct: false, note: 'no verdict' }
+    perProblem.push({
+      id: c.id,
+      tier: t,
+      arm,
+      answer: a.answer,
+      refused: !!a.refused,
+      confident: !!a.confident,
+      tool_calls: a.tool_calls || 0,
+      correct: !!v.correct,
+      wrong_confident: !!a.confident && !v.correct && !a.refused,
+    })
+  }
+}
+
+function tally(rows) {
+  const total = rows.length
+  const correct = rows.filter((r) => r.correct).length
+  const refused = rows.filter((r) => r.refused).length
+  const wrongConfident = rows.filter((r) => r.wrong_confident).length
+  const toolCalls = rows.reduce((s, r) => s + (r.tool_calls || 0), 0)
+  return { total, correct, refused, wrongConfident, toolCalls }
+}
+
+const summary = { overall: {}, byTier: {} }
+for (const arm of arms) summary.overall[arm] = tally(perProblem.filter((r) => r.arm === arm))
+for (const t of tiers) {
+  summary.byTier[t] = {}
+  for (const arm of arms) {
+    summary.byTier[t][arm] = tally(perProblem.filter((r) => r.arm === arm && r.tier === t))
+  }
+}
+
+log(
+  `no_tools ${summary.overall.no_tools.correct}/${summary.overall.no_tools.total}` +
+    ` vs sage ${summary.overall.sage.correct}/${summary.overall.sage.total}`,
+)
+
+return { tiers, arms, subjectModel: SUBJECT_MODEL, judgeModel: JUDGE_MODEL, perProblem, summary }

--- a/scripts/write_benchmark_stats.py
+++ b/scripts/write_benchmark_stats.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Render ``benchmark-stats.md`` from an outcome-benchmark result JSON.
+
+The benchmark itself is the Workflow in ``benchmarks/outcome_benchmark.workflow.js``:
+it runs the fixed case set (``benchmarks/cases.json``) through the model twice --
+reasoning alone vs. with SageMath compute -- and scores every answer for
+equivalence in Sage. That Workflow returns a JSON object (``perProblem`` +
+``summary``); this script turns it into the published table, the way the doctest
+corpus sweep writes ``doctest-corpus-stats.md``.
+
+Usage:
+    python scripts/write_benchmark_stats.py <result.json> [--generated "<when>"]
+
+Kept separate from the Workflow so the numbers can be re-rendered without
+re-running the model, and so the render is plain, reviewable Python.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+
+STATS = "benchmark-stats.md"
+ARM_LABEL = {"no_tools": "Reasoning only", "sage": "With Sage compute"}
+
+
+def _acc(t: dict) -> str:
+    return f"{t['correct']}/{t['total']}" + (
+        f" ({100.0 * t['correct'] / t['total']:.0f}%)" if t["total"] else ""
+    )
+
+
+def render(data: dict, generated: str) -> str:
+    summary = data["summary"]
+    tiers = data["tiers"]
+    arms = data["arms"]
+    per = data["perProblem"]
+
+    overall = summary["overall"]
+    nt, sg = overall["no_tools"], overall["sage"]
+    delta = sg["correct"] - nt["correct"]
+
+    lines = [
+        "# Outcome benchmark",
+        "",
+        "Does the model get more mathematics right when it can run Sage, versus",
+        "reasoning alone? Two arms over the fixed case set in `benchmarks/cases.json`,",
+        "every answer scored for *mathematical equivalence* in the SageMath 10.9",
+        "container (not string-matched). Produced by",
+        "`benchmarks/outcome_benchmark.workflow.js`.",
+        "",
+        f"- Generated: {generated}",
+        f"- Cases: {nt['total']} across tiers: {', '.join(tiers)}",
+        f"- Subject model (under test): `{data.get('subjectModel', 'unknown')}`"
+        f"; scoring judge: `{data.get('judgeModel', 'unknown')}`",
+        "- This is as much a measurement of the subject model as of the server; a",
+        "  stronger model closes the gap on its own. Never CI-gated.",
+        "",
+        "## Headline",
+        "",
+        "| Arm | Correct | Wrong-confident | Refused | Sage calls |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for arm in arms:
+        t = overall[arm]
+        lines.append(
+            f"| {ARM_LABEL.get(arm, arm)} | {_acc(t)} | {t['wrongConfident']} "
+            f"| {t['refused']} | {t['toolCalls']} |"
+        )
+    lines += [
+        "",
+        f"**Delta: +{delta}** answers correct with Sage compute "
+        f"({_acc(nt)} → {_acc(sg)}).",
+        "",
+        "## By tier",
+        "",
+        "| Tier | Reasoning only | With Sage | Delta |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    for tier in tiers:
+        bt = summary["byTier"][tier]
+        d = bt["sage"]["correct"] - bt["no_tools"]["correct"]
+        sign = f"+{d}" if d > 0 else str(d)
+        lines.append(f"| {tier} | {_acc(bt['no_tools'])} | {_acc(bt['sage'])} | {sign} |")
+
+    lines += [
+        "",
+        "## Per problem",
+        "",
+        "A ✗ in *Reasoning only* that is ✓ *With Sage* is the value the server adds;",
+        "a wrong-confident cell (⚠) is the failure mode `verify_claim` exists for.",
+        "",
+        "| ID | Tier | Reasoning only | With Sage |",
+        "| --- | --- | :---: | :---: |",
+    ]
+    by_id: dict[str, dict[str, dict]] = {}
+    for r in per:
+        by_id.setdefault(r["id"], {})[r["arm"]] = r
+    for pid in sorted(by_id):
+        row = by_id[pid]
+        tier = next(iter(row.values()))["tier"]
+        cells = []
+        for arm in arms:
+            r = row.get(arm, {})
+            if r.get("refused"):
+                cells.append("— (refused)")
+            elif r.get("correct"):
+                cells.append("✓")
+            elif r.get("wrong_confident"):
+                cells.append("⚠ wrong")
+            else:
+                cells.append("✗")
+        lines.append(f"| {pid} | {tier} | {cells[0]} | {cells[1]} |")
+
+    lines += [
+        "",
+        "## Method and honest limits",
+        "",
+        "- The two arms are the **same model**; one is told to reason unaided, the",
+        "  other to compute and verify with Sage. The delta is the lift from having",
+        "  the CAS in the loop.",
+        "- *Reasoning only* is **prompt-enforced**: the agent is told not to execute",
+        "  anything and self-reports zero tool calls. It is not hard tool-gated. The",
+        "  rigorous three-arm version (no-tools / `evaluate_sage`-only / full",
+        "  catalogue, with real gating) is the `tests/cli_integration` harness, which",
+        "  runs under the CLI nightlies with API keys.",
+        "- Answers are scored by an **independent** Sage-backed step, so a plausible",
+        "  wrong answer is caught, not accepted on its wording.",
+        "- Small, fixed, seeded case set: this is a directional signal a run can",
+        "  reproduce, not a leaderboard number. Grow `benchmarks/cases.json` to",
+        "  tighten it.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("result", help="Path to the Workflow result JSON.")
+    ap.add_argument("--generated", default="on demand", help="Timestamp for the stats file.")
+    args = ap.parse_args()
+    data = json.loads(pathlib.Path(args.result).read_text(encoding="utf-8"))
+    pathlib.Path(STATS).write_text(render(data, args.generated), encoding="utf-8")
+    print(f"Wrote {STATS}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

The doctest corpus sweep proves the guardrails don't *refuse* mathematics. This measures the other claim the roadmap asks for: **does a model get more mathematics *right* when it can run Sage?**

- **`benchmarks/cases.json`** — a fixed, seeded case set: 24 problems in five difficulty tiers (arithmetic → competition → advanced → compute-heavy → infeasible). Every gold answer is verified in the SageMath 10.9 container.
- **`benchmarks/outcome_benchmark.workflow.js`** — a Workflow that runs the set through the model twice, **reasoning alone vs. with Sage compute**, and scores every answer for *mathematical equivalence* in Sage by an **independent** step (never string-matched).
- **`scripts/write_benchmark_stats.py`** → **`benchmark-stats.md`**, the way the corpus sweep writes its stats.

## Result (first run)

Subject model **`haiku`**, judge **`sonnet`**:

| Tier | Reasoning only | With Sage |
| --- | ---: | ---: |
| arithmetic (GSM8K-style) | 4/4 | 4/4 |
| competition (MATH-style) | 5/5 | 5/5 |
| advanced (CAS-suited) | 5/5 | 5/5 |
| compute-heavy | 3/5 | 5/5 |
| infeasible (factoring, 8×8 det, partitions, huge modexp) | 0/5 | 5/5 |
| **Total** | **17/24 (71%)** | **24/24 (100%)** |

**Delta +7**, entirely in the last two tiers — arbitrary computation no model can do in-context. There, reasoning alone **refused six** and answered **one confidently wrong** (263681 read as 463681 — the failure mode `verify_claim` exists for), while Sage got all ten. On problems the model already handles, both arms are 100%: the tool doesn't help where it isn't needed, and doesn't hurt.

## Why Haiku

A frontier model (Opus) solves the *entire* set unaided — zero delta, nothing to show. The subject is deliberately a lower-tier model so the tool's value is visible; both arms use the **same** subject, so the only variable is Sage access. A stronger model closes the gap on its own, which is why this is **never CI-gated** — it measures the model as much as the server.

## Honest limits

- *Reasoning only* is **prompt-enforced** (the agent is told not to execute anything and self-reports zero tool calls), not hard tool-gated. Verified the no-tools agents made no execution calls on the hard tier.
- The rigorous **three-arm** version (no-tools / `evaluate_sage`-only / full-catalogue, with real gating and the wrong-confident/refusal/latency breakdown) belongs in `tests/cli_integration` under the CLI nightlies, where per-client keys live — tracked as follow-up in ROADMAP/TODO.
- Small, fixed, seeded set: a reproducible directional signal, not a leaderboard number. Grow `cases.json` to tighten it.

No `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)