### PR TITLE
Close external-review round 3: verifier exactness boundary + warm-pool ownership

### DIFF
--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -3815,3 +3815,44 @@ and the membership/identity fall-through.
 
 Fixed 2026-09-07; found by an external review at 356d520. Builds on items 71
 (round 2) and 65/68.
+
+## 74. Warm-pool reclamation releases a worker's slot before it exits — medium — DONE
+
+### What
+
+The capacity-reclamation path (external review, round 3) freed a slot before the
+worker holding it had exited: `get` cancelled a refill task and dropped its spare
+from `_warm_in_flight` *before* awaiting shutdown, then created the replacement
+immediately. With a refill in flight, that left three live processes for a
+ceiling of two. The root cause is that a cancelled task cannot reliably shut its
+own worker down -- `await spare.shutdown()` in the task's `except` gets a
+re-delivered `CancelledError` that `suppress` swallows mid-shutdown -- so even
+`manager.shutdown()` could return with an owned worker still alive.
+
+### Fix
+
+Ownership through cleanup, done by the canceller in an uncancelled context:
+
+- `_warm_tasks` is now `{task: spare}`, so whoever cancels a refill holds the
+  worker to reclaim.
+- On `CancelledError`, `_spawn_warm_worker` re-raises WITHOUT shutting down and
+  leaves the spare in `_warm_in_flight` -- the canceller owns it.
+- `_reclaim_refill(task, spare)` cancels the task, awaits it, shuts the spare
+  down in the caller's context, and only then drops it from `_warm_in_flight`.
+  `get` awaits reclamation before creating the replacement, so the slot is
+  genuinely free (worker exited), not merely signalled.
+- `shutdown` reclaims `_warm_pool` + `_warm_in_flight` in its own context, so a
+  cancelled refill's worker is always cleaned up.
+
+### How to verify
+
+`tests/test_warm_pool.py::test_reclaim_awaits_the_worker_exit_before_reusing_the_slot`
+holds a refill spare alive mid warm-up with a real worker subprocess, has a
+second client trigger reclamation, and asserts the reclaimed worker is no longer
+alive, `_warm_in_flight`/`_warm_tasks` are empty, and live workers stay within
+the ceiling. Plus the round-2 ceiling and cancelled-refill tests. 100% coverage.
+
+### Status
+
+Fixed 2026-09-07; found by an external review at 356d520. `SAGEMATH_MCP_WARM_POOL_SIZE=0`
+was the interim mitigation and is no longer needed.

--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -3774,3 +3774,44 @@ alive). Both use the pure-Python worker.
 
 Fixed 2026-09-07; found by an external review at cc4a8ae. `SAGEMATH_MCP_WARM_POOL_SIZE=0`
 was the interim mitigation and is no longer needed.
+
+## 73. Verifier: dict keys and bare predicates still earned exact verdicts — high — DONE
+
+### What
+
+Two proof paths still returned `proved/exact_comparison` for rounded results
+(external review, round 3):
+
+- **Dict keys.** `_is_inexact` recursed into a dict's values but not its keys,
+  so `{RR(1)+RR(1)/10^20: 0} == {RR(1): 0}` was proved exact.
+- **Bare predicates.** A claim with no top-level comparison
+  (`(RR(1)+RR(1)/10^20-RR(1)).is_zero()`) has no sides to inspect; operand
+  inspection never ran, and the resulting Boolean took the exact path.
+
+The comparison path also re-evaluated the operand *source* after evaluating the
+whole claim, rather than checking the values the comparison actually used.
+
+### Fix
+
+- `_is_inexact` now checks dict keys and values.
+- `_comparison_sides` returns the operator and slices the operands' ORIGINAL
+  substrings (not `ast.unparse`, whose bit-xor precedence would turn `x^2 - 1`
+  into `x^(2 - 1)`); the generated code evaluates each side ONCE, checks the
+  retained values' exactness, and builds the relation from them.
+- `_predicate_operand_sources` extracts a bare predicate's receiver and
+  arguments from the source; the generated code checks their exactness, and a
+  predicate whose inputs cannot be established is qualified, not proved.
+
+### How to verify
+
+`tests/test_verify.py`, real Sage: the dict-key and `is_zero()` claims are
+`supported/float_comparison`; `is_prime(7)` stays `proved`; and
+`x^2 - 2*x + 1 = (x - 1)^2` stays `proved/symbolic_prover` (the precedence trap
+would have refuted it). 34 verify tests pass; `_comparison_sides` /
+`_predicate_operand_sources` unit tests cover the operator, the `^` substring,
+and the membership/identity fall-through.
+
+### Status
+
+Fixed 2026-09-07; found by an external review at 356d520. Builds on items 71
+(round 2) and 65/68.

--- a/src/sagemath_mcp/session.py
+++ b/src/sagemath_mcp/session.py
@@ -751,7 +751,10 @@ class SageSessionManager:
         # warm_up() at server start and topped up in the background; the refill
         # tasks are tracked so shutdown can cancel them.
         self._warm_pool: list[SageSession] = []
-        self._warm_tasks: set[asyncio.Task[None]] = set()
+        # Refill task -> the spare it is warming, so whoever cancels a refill
+        # holds a reference to reclaim that worker in its own (uncancelled)
+        # context. A cancelled task cannot reliably shut its own worker down.
+        self._warm_tasks: dict[asyncio.Task[None], SageSession] = {}
         # Spares whose refill is still running -- tracked so a cancelled refill
         # (shutdown, or a real session reclaiming its slot) cannot leak the
         # worker it had already spawned, and so total-worker accounting can see
@@ -862,16 +865,21 @@ class SageSessionManager:
             if not await self._spawn_warm_worker():
                 break
 
-    async def _spawn_warm_worker(self) -> bool:
-        """Add one fully-warmed spare to the pool. Returns whether it landed.
+    async def _spawn_warm_worker(self, spare: SageSession | None = None) -> bool:
+        """Warm one spare and add it to the pool. Returns whether it landed.
 
         Spawning imports Sage, but the expensive part is the *first evaluation*
         -- Sage defers a second of lazy setup to it (~1.3s measured, then ~2ms).
         So the spare runs a throwaway `1+1` here, off any client's critical path,
         and its journal is wiped so it is pristine when adopted.
+
+        The spare is created by the caller when this runs as a cancellable refill
+        task (`_schedule_warm_refill`), so the canceller keeps a reference to it;
+        `warm_up` passes ``None`` and one is made here.
         """
-        spare = SageSession(_WARM_SPARE_ID, self.settings)
-        self._warm_in_flight.add(spare)
+        if spare is None:
+            spare = SageSession(_WARM_SPARE_ID, self.settings)
+            self._warm_in_flight.add(spare)
         try:
             await spare.ensure_started()
             await spare.evaluate(
@@ -881,23 +889,39 @@ class SageSessionManager:
                 timeout_seconds=min(_WARM_EVAL_TIMEOUT, self.settings.eval_timeout),
             )
             spare._code_journal.clear()
-        except BaseException as exc:
-            # `BaseException`, not `Exception`, on purpose: `CancelledError` (the
-            # refill task being cancelled at shutdown or to free a slot for a
-            # real session) does not derive from `Exception`, and the earlier
-            # `except Exception` let it skip cleanup -- leaving the spawned worker
-            # alive. Reclaim it either way; re-raise a cancellation so the task
-            # still counts as cancelled.
-            self._warm_in_flight.discard(spare)
-            with contextlib.suppress(BaseException):
+        except asyncio.CancelledError:
+            # Do NOT shut the worker down here. Awaiting a shutdown inside a
+            # cancelled task is unreliable -- a re-delivered cancellation is
+            # swallowed mid-way and the worker survives, which is exactly the
+            # leak the reviewer reproduced. The spare stays in `_warm_in_flight`;
+            # whoever cancelled this refill (get's reclaim, or shutdown) owns the
+            # cleanup and performs it in an uncancelled context.
+            raise
+        except Exception as exc:
+            with contextlib.suppress(Exception):
                 await spare.shutdown()
-            if isinstance(exc, asyncio.CancelledError):
-                raise
+            self._warm_in_flight.discard(spare)
             LOGGER.warning("Could not pre-warm a spare Sage worker: %s", exc)
             return False
         self._warm_in_flight.discard(spare)
         self._warm_pool.append(spare)
         return True
+
+    async def _reclaim_refill(self, task: asyncio.Task[None], spare: SageSession) -> None:
+        """Cancel a refill and release its worker before its slot is reused.
+
+        Awaits the cancelled task, then shuts its spare down here -- in the
+        caller's uncancelled context, where the shutdown actually completes --
+        and only then drops it from `_warm_in_flight`. So the capacity a
+        replacement takes is genuinely free: the worker has exited, not merely
+        been signalled.
+        """
+        task.cancel()
+        with contextlib.suppress(BaseException):
+            await asyncio.gather(task, return_exceptions=True)
+        with contextlib.suppress(Exception):
+            await spare.shutdown()
+        self._warm_in_flight.discard(spare)
 
     def _schedule_warm_refill(self) -> None:
         """Top the pool back up in the background after a spare is adopted.
@@ -913,9 +937,11 @@ class SageSessionManager:
             return
         if limit and committed >= limit:
             return
-        task = asyncio.create_task(self._spawn_warm_worker())
-        self._warm_tasks.add(task)
-        task.add_done_callback(self._warm_tasks.discard)
+        spare = SageSession(_WARM_SPARE_ID, self.settings)
+        self._warm_in_flight.add(spare)
+        task = asyncio.create_task(self._spawn_warm_worker(spare))
+        self._warm_tasks[task] = spare
+        task.add_done_callback(lambda t: self._warm_tasks.pop(t, None))
 
     async def get(self, session_id: str) -> SageSession:
         adopted = False
@@ -949,16 +975,18 @@ class SageSessionManager:
                     # refill's slot first. Without this, `get` counted only
                     # `_sessions` while the refill counted its own slot, so a
                     # spare and a new session could both take the last slot and
-                    # overshoot max_sessions (CAP 2 LIVE 2 SPARES 1).
-                    if limit:
-                        while (
-                            len(self._sessions) + len(self._warm_pool) + len(self._warm_tasks)
-                            >= limit
-                            and self._warm_tasks
-                        ):
-                            victim = next(iter(self._warm_tasks))
-                            self._warm_tasks.discard(victim)
-                            victim.cancel()
+                    # overshoot max_sessions (CAP 2 LIVE 2 SPARES 1). Reclamation
+                    # AWAITS the worker's exit before the slot is reused, so the
+                    # replacement does not start alongside a still-live spare.
+                    while (
+                        limit
+                        and len(self._sessions) + len(self._warm_pool) + len(self._warm_tasks)
+                        >= limit
+                        and self._warm_tasks
+                    ):
+                        victim, victim_spare = next(iter(self._warm_tasks.items()))
+                        del self._warm_tasks[victim]
+                        await self._reclaim_refill(victim, victim_spare)
                     session = SageSession(session_id, self.settings)
                     adopted = False
                 self._sessions[session_id] = session

--- a/src/sagemath_mcp/tools/verify.py
+++ b/src/sagemath_mcp/tools/verify.py
@@ -102,26 +102,80 @@ def _exact_decimal_literals(claim: str) -> str:
     return rewritten
 
 
-def _comparison_sides(claim: str) -> tuple[str | None, str | None]:
-    """The two operands of the claim's single top-level comparison.
+_AST_COMPARE_OPS = {
+    ast.Eq: "==",
+    ast.NotEq: "!=",
+    ast.Lt: "<",
+    ast.LtE: "<=",
+    ast.Gt: ">",
+    ast.GtE: ">=",
+}
 
-    Returned as source strings so the generated code can evaluate each side on
-    its own and inspect its exactness -- which the collapsed Boolean has already
-    thrown away. `RR(1) + RR(1)/10^20 == RR(1)` evaluates to True by
-    floating-point rounding, and without the operands the ladder called that an
-    exact proof; with them it can see both sides live in an inexact field and
-    refuse the exact verdict. Only a single comparison is handled (the
-    truth-assembly gate guarantees there is at most one); a bare predicate like
-    `is_prime(7)` has no sides and is left to whole-claim evaluation.
+
+def _comparison_sides(claim: str) -> tuple[str | None, str | None, str | None]:
+    """The two operands and operator of the claim's single top-level comparison.
+
+    Returned as source strings so the generated code can evaluate each side
+    *once*, inspect its exactness, and build the comparison from those retained
+    values -- rather than re-evaluating the source after the collapsed Boolean
+    has already thrown the operands away. `RR(1) + RR(1)/10^20 == RR(1)`
+    evaluates to True by floating-point rounding; with the sides the ladder sees
+    both live in an inexact field and refuses the exact verdict. Only a single
+    comparison is handled (the truth-assembly gate guarantees at most one); a
+    bare predicate like `is_prime(7)` has no sides and is left to whole-claim
+    evaluation (its inputs are inspected via `_predicate_operand_sources`).
     """
     candidate = _EQUALS_NOT_COMPARISON.sub("==", claim)
     try:
         node = ast.parse(candidate, mode="eval").body
     except SyntaxError:
-        return (None, None)
+        return (None, None, None)
     if isinstance(node, ast.Compare) and len(node.ops) == 1:
-        return (ast.unparse(node.left), ast.unparse(node.comparators[0]))
-    return (None, None)
+        op = _AST_COMPARE_OPS.get(type(node.ops[0]))
+        if op is not None:
+            # Slice the ORIGINAL substrings, never ast.unparse: `^` is Python
+            # bit-xor (looser than +/-/*), so unparsing `x^2 - 2*x + 1` yields
+            # `x ^ (2 - 2*x + 1)` -- the wrong expression once Sage's preparser
+            # reads `^` as a power. The claim is whitespace-folded to one line,
+            # so column offsets index it directly.
+            return (
+                candidate[node.left.col_offset : node.left.end_col_offset],
+                candidate[node.comparators[0].col_offset : node.comparators[0].end_col_offset],
+                op,
+            )
+    return (None, None, None)
+
+
+def _predicate_operand_sources(claim: str) -> list[str]:
+    """Operand sources for a claim that is *not* a top-level comparison.
+
+    A bare predicate collapses to a Boolean that cannot reveal its own
+    provenance -- `(RR(1)+RR(1)/10^20-RR(1)).is_zero()` returns True by rounding,
+    with no comparison sides for the ladder to inspect, so it was proved exact.
+    The exactness check reads the predicate's inputs from the source instead: the
+    receiver and arguments of a top-level call (`X.is_zero()` -> `[X]`,
+    `is_prime(n)` -> `[n]`), otherwise the whole expression. Empty when the claim
+    IS a comparison -- that path already inspects its two sides.
+    """
+    candidate = _EQUALS_NOT_COMPARISON.sub("==", claim)
+    try:
+        node = ast.parse(candidate, mode="eval").body
+    except SyntaxError:
+        return []
+    def _src(sub: ast.AST) -> str:
+        # Original substring, not ast.unparse -- see _comparison_sides on why `^`
+        # cannot survive a round-trip through the Python AST.
+        return candidate[sub.col_offset : sub.end_col_offset]
+
+    if isinstance(node, ast.Compare):
+        return []
+    if isinstance(node, ast.Call):
+        sources: list[str] = []
+        if isinstance(node.func, ast.Attribute):
+            sources.append(_src(node.func.value))
+        sources.extend(_src(a) for a in node.args if not isinstance(a, ast.Starred))
+        return sources or [_src(node)]
+    return [_src(node)]
 
 
 def _reject_truth_assembly(claim: str) -> None:
@@ -237,10 +291,16 @@ async def verify_claim(
         # judging anything other than the final text is how item 55 happened.
         claim = _validated_expression(rewritten)
     _reject_truth_assembly(claim)
-    lhs_src, rhs_src = _comparison_sides(claim)
+    lhs_src, rhs_src, op_src = _comparison_sides(claim)
     have_sides = lhs_src is not None and rhs_src is not None
     lhs_literal = _encode_literal(lhs_src) if have_sides else "None"
     rhs_literal = _encode_literal(rhs_src) if have_sides else "None"
+    op_literal = _encode_literal(op_src) if have_sides else "None"
+    # For a bare predicate (no top-level comparison), the values to check for
+    # exactness are the predicate's own operands, read from the source -- the
+    # collapsed Boolean cannot reveal them. Encoded as literals like the sides.
+    operand_srcs = _predicate_operand_sources(claim)
+    operand_srcs_literal = "[" + ", ".join(_encode_literal(s) for s in operand_srcs) + "]"
     code = (
         _sage_prelude()
         + textwrap.dedent(
@@ -248,16 +308,40 @@ async def verify_claim(
         _text = {_encode_literal(claim)}
         _lhs_src = {lhs_literal}
         _rhs_src = {rhs_literal}
+        _op_src = {op_literal}
+        _operand_srcs = {operand_srcs_literal}
         _nsamples = {int(samples)}
         _prec = {int(precision_bits)}
-        try:
-            _claim = sage_eval(_text, locals=_locals)
-        except SyntaxError:
-            _sides = _text.split('=')
-            if len(_sides) != 2:
-                raise
-            _claim = (sage_eval(_sides[0].strip(), locals=_locals)
-                      == sage_eval(_sides[1].strip(), locals=_locals))
+        # When the claim is a single comparison, evaluate each side EXACTLY ONCE
+        # and build the relation from those retained values -- so the exactness
+        # check below inspects the very values the comparison used, not a second
+        # evaluation of the source (which a non-deterministic function could make
+        # disagree). Bare predicates have no sides and are evaluated whole.
+        _lhs_v = _rhs_v = None
+        if _lhs_src is not None:
+            _lhs_v = sage_eval(_lhs_src, locals=_locals)
+            _rhs_v = sage_eval(_rhs_src, locals=_locals)
+            if _op_src == '==':
+                _claim = (_lhs_v == _rhs_v)
+            elif _op_src == '!=':
+                _claim = (_lhs_v != _rhs_v)
+            elif _op_src == '<':
+                _claim = (_lhs_v < _rhs_v)
+            elif _op_src == '<=':
+                _claim = (_lhs_v <= _rhs_v)
+            elif _op_src == '>':
+                _claim = (_lhs_v > _rhs_v)
+            else:
+                _claim = (_lhs_v >= _rhs_v)
+        else:
+            try:
+                _claim = sage_eval(_text, locals=_locals)
+            except SyntaxError:
+                _sides = _text.split('=')
+                if len(_sides) != 2:
+                    raise
+                _claim = (sage_eval(_sides[0].strip(), locals=_locals)
+                          == sage_eval(_sides[1].strip(), locals=_locals))
         def _symbolic_is_inexact(_e):
             # A symbolic expression is exact only if every numeric constant in it
             # is exact. Walk the tree; a leaf that wraps a machine number
@@ -299,7 +383,12 @@ async def verify_claim(
             if isinstance(_v, (list, tuple, set, frozenset)):
                 return any(_is_inexact(_e) for _e in _v)
             if isinstance(_v, dict):
-                return any(_is_inexact(_e) for _e in _v.values())
+                # Keys take part in equality too -- a dict with an inexact key
+                # and an exact value must still count -- so check both, not just
+                # values.
+                return any(_is_inexact(_e) for _e in _v.keys()) or any(
+                    _is_inexact(_e) for _e in _v.values()
+                )
             try:
                 _p = _v.parent()
             except AttributeError:
@@ -364,16 +453,24 @@ async def verify_claim(
             return True
         _inexact_operands = False
         try:
-            if hasattr(_claim, 'is_relational') and _claim.is_relational():
-                # Inspect the claim's OWN operands, not a second evaluation of
-                # the source: a function that returns different values on two
-                # calls could otherwise be judged exact and run exact.
+            if _lhs_src is not None:
+                # A comparison: inspect the retained side values, the very ones
+                # the relation above was built from -- not a second evaluation
+                # of the source.
+                _inexact_operands = _is_inexact(_lhs_v) or _is_inexact(_rhs_v)
+            elif isinstance(_claim, bool):
+                # A bare predicate (no comparison sides). The collapsed Boolean
+                # cannot reveal its provenance, so inspect the predicate's own
+                # operands, read from the source. No operands to check (an opaque
+                # predicate) is itself unestablished provenance -> qualify.
+                if _operand_srcs:
+                    _inexact_operands = any(
+                        _is_inexact(sage_eval(_s, locals=_locals)) for _s in _operand_srcs
+                    )
+                else:
+                    _inexact_operands = True
+            elif hasattr(_claim, 'is_relational') and _claim.is_relational():
                 _inexact_operands = _is_inexact(_claim.lhs()) or _is_inexact(_claim.rhs())
-            elif isinstance(_claim, bool) and _lhs_src is not None:
-                _inexact_operands = (
-                    _is_inexact(sage_eval(_lhs_src, locals=_locals))
-                    or _is_inexact(sage_eval(_rhs_src, locals=_locals))
-                )
         except Exception:
             _inexact_operands = True  # cannot establish exactness -> qualify, never prove
         _verdict = None

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -128,16 +128,26 @@ async def test_verify_claim_reads_decimal_literals_exactly(claim, expected, monk
 
 
 def test_comparison_sides_splits_a_single_comparison():
-    from sagemath_mcp.tools.verify import _comparison_sides
+    from sagemath_mcp.tools.verify import _comparison_sides, _predicate_operand_sources
 
-    assert _comparison_sides("RR(1) == RR(2)") == ("RR(1)", "RR(2)")
-    # The equation spelling is normalized before splitting.
-    lhs, rhs = _comparison_sides("x^2 - 1 = 0")
-    assert lhs.replace(" ", "") == "x^2-1" and rhs == "0"
-    # A bare predicate has no comparison sides.
-    assert _comparison_sides("is_prime(7)") == (None, None)
+    assert _comparison_sides("RR(1) == RR(2)") == ("RR(1)", "RR(2)", "==")
+    # The equation spelling is normalized before splitting, and the sides keep
+    # their ORIGINAL text -- `^` must not round-trip through the Python AST
+    # (bit-xor precedence would turn `x^2 - 1` into `x^(2 - 1)`).
+    lhs, rhs, op = _comparison_sides("x^2 - 1 = 0")
+    assert lhs.replace(" ", "") == "x^2-1" and rhs == "0" and op == "=="
+    assert _comparison_sides("e^pi != pi^e") == ("e^pi", "pi^e", "!=")
+    # A bare predicate has no comparison sides; its operands are read instead.
+    assert _comparison_sides("is_prime(7)") == (None, None, None)
+    assert _predicate_operand_sources("is_prime(7)") == ["7"]
+    assert _predicate_operand_sources("(RR(1)+RR(1)/10^20).is_zero()") == [
+        "RR(1)+RR(1)/10^20"
+    ]
+    # A comparison whose operator is not one of the six ordering/equality ops
+    # (membership, identity) has no proof-grade sides: whole-claim evaluation.
+    assert _comparison_sides("x in (1, 2, 3)") == (None, None, None)
     # Sage-only syntax that does not parse: no sides, falls back to whole-claim.
-    assert _comparison_sides("R.<a> = QQ[]") == (None, None)
+    assert _comparison_sides("R.<a> = QQ[]") == (None, None, None)
 
 
 async def test_verify_claim_accepts_the_equation_spelling(monkeypatch):
@@ -397,5 +407,21 @@ async def test_verify_claim_ladder_against_real_sage(monkeypatch):
         assert alg.method == "exact_algebraic"
         assert "x is integer" in alg.assumptions
         assert "integer" in (alg.evidence or "")
+
+        # External-review round 3: two more paths that mistook a rounded result
+        # for exact evidence. A dict with an inexact KEY (not just values), and a
+        # bare predicate whose collapsed Boolean hid its inexact input.
+        dict_key = await server.verify_claim("{RR(1)+RR(1)/10^20: 0} == {RR(1): 0}", ctx=ctx)
+        assert dict_key.verdict == "supported"
+        assert dict_key.method == "float_comparison"
+        predicate = await server.verify_claim("(RR(1)+RR(1)/10^20-RR(1)).is_zero()", ctx=ctx)
+        assert predicate.verdict == "supported"
+        assert predicate.method == "float_comparison"
+        # Exact bare predicates are still decided, and the `^`-precedence trap of
+        # rebuilding a comparison from its parsed sides does not corrupt a true
+        # identity into a refutation.
+        assert (await server.verify_claim("is_prime(7)", ctx=ctx)).verdict == "proved"
+        power = await server.verify_claim("x^2 - 2*x + 1 = (x - 1)^2", ctx=ctx)
+        assert power.verdict == "proved"
     finally:
         await manager.shutdown()

--- a/tests/test_warm_pool.py
+++ b/tests/test_warm_pool.py
@@ -122,7 +122,7 @@ async def test_shutdown_cancels_a_pending_refill(monkeypatch):
 
     stuck = asyncio.Event()
 
-    async def never_finishes():
+    async def never_finishes(spare=None):
         await stuck.wait()  # never set -> the refill task stays pending
         return True
 
@@ -154,10 +154,10 @@ async def test_a_refill_never_pushes_the_total_over_the_ceiling(monkeypatch):
         release = asyncio.Event()
         real_spawn = manager._spawn_warm_worker
 
-        async def blocking_spawn():
+        async def blocking_spawn(spare=None):
             started.set()
             await release.wait()
-            return await real_spawn()
+            return await real_spawn(spare)
 
         monkeypatch.setattr(manager, "_spawn_warm_worker", blocking_spawn)
 
@@ -223,5 +223,44 @@ async def test_warm_up_respects_the_session_ceiling():
     try:
         await manager.warm_up()
         assert len(manager._warm_pool) == 1
+    finally:
+        await manager.shutdown()
+
+
+async def test_reclaim_awaits_the_worker_exit_before_reusing_the_slot(monkeypatch):
+    """Capacity reclamation must not release a slot until the spare's worker has
+    actually exited (external review, round 3). Previously get() cancelled the
+    refill and dropped the spare from tracking without awaiting its shutdown, so
+    the replacement could start while the cancelled worker was still alive --
+    three live processes for a ceiling of two.
+    """
+    manager = SageSessionManager(_settings(max_sessions=2, warm_pool_size=1))
+    await manager.warm_up()  # W0 pooled (unpatched, so its warm eval completed)
+
+    entered = asyncio.Event()
+    real_eval = SageSession.evaluate
+
+    async def blocking_eval(self, *args, **kwargs):
+        # Hold the *refill* spare alive, mid warm-up, when B arrives.
+        if self.session_id == _WARM_SPARE_ID and not entered.is_set():
+            entered.set()
+            await asyncio.Event().wait()  # until cancelled by the reclaim
+        return await real_eval(self, *args, **kwargs)
+
+    monkeypatch.setattr(SageSession, "evaluate", blocking_eval)
+    try:
+        await manager.get("A")  # adopts W0, schedules the refill for W1
+        await asyncio.wait_for(entered.wait(), 3)  # W1 spawned and alive, blocked
+        assert len(manager._warm_in_flight) == 1
+        spare = next(iter(manager._warm_in_flight))
+        assert spare.is_alive()
+
+        await manager.get("B")  # must reclaim W1 (await its exit) before creating B
+
+        assert not spare.is_alive(), "reclaimed worker still alive after the slot was reused"
+        assert not manager._warm_in_flight
+        assert not manager._warm_tasks
+        live = [s for s in manager._sessions.values() if s.is_alive()]
+        assert len(live) <= 2
     finally:
         await manager.shutdown()


### PR DESCRIPTION
The two findings the reviewer left open at 356d520, both verified against real Sage / real worker subprocesses. REVIEW_ACTIONS 73–74.

## 1. High — verifier still earned exact verdicts on two paths (REVIEW_ACTIONS 73)
- **Dict keys:** `_is_inexact` recursed into a dict's values but not its keys, so `{RR(1)+RR(1)/10^20: 0} == {RR(1): 0}` was `proved/exact_comparison`. It now checks both. → `supported/float_comparison`.
- **Bare predicates:** a claim with no top-level comparison (`(RR(1)+RR(1)/10^20-RR(1)).is_zero()`) had no sides to inspect, so its collapsed Boolean took the exact path. `_predicate_operand_sources` now extracts the predicate's receiver/arguments from the source and the ladder checks their exactness; unestablished provenance is qualified, not proved. → `supported/float_comparison`.
- **Provenance:** `_comparison_sides` returns the operator and slices the operands' **original** substrings (not `ast.unparse`, whose bit-xor precedence would corrupt `x^2 - 1` into `x^(2 - 1)`); the generated code evaluates each side **once**, checks the retained values, and builds the relation from them.

`is_prime(7)` stays `proved`; `x^2 - 2*x + 1 = (x - 1)^2` stays `proved` (the precedence trap would have refuted it). 34 verify tests pass.

## 2. Medium — warm-pool reclamation released a slot before the worker exited (REVIEW_ACTIONS 74)
`get` cancelled a refill and dropped its spare from tracking **before** awaiting shutdown, then created the replacement — three live processes for a ceiling of two. A cancelled task can't reliably shut its own worker down (a re-delivered `CancelledError` is swallowed mid-shutdown), so even `manager.shutdown()` could return with an owned worker alive.

Fix — **ownership through cleanup**, performed by the canceller in an uncancelled context: `_warm_tasks` maps `task → spare`; a cancelled refill re-raises without shutting down and leaves its spare tracked; `_reclaim_refill` cancels, awaits the task, shuts the spare down, then drops it; `get` awaits reclamation before creating the replacement; `shutdown` reclaims pool + in-flight in its own context. New test spawns a real worker, pauses it in flight, reclaims it via a second client, and asserts the **process actually exited** and the ceiling held.

## Verification
- Pure-Python suite: 1025 passed; **100% statement/branch coverage**; lint clean.
- Real Sage (container): `tests/test_verify.py` 34 passed, including the round-3 dict-key, bare-predicate and `^`-precedence cases.

With these, the two remaining findings from the review are closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)