### PR TITLE
Round-4 review response: verifier exactness + Unicode, warm-pool cancellation

### DIFF
--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -3856,3 +3856,49 @@ the ceiling. Plus the round-2 ceiling and cancelled-refill tests. 100% coverage.
 
 Fixed 2026-09-07; found by an external review at 356d520. `SAGEMATH_MCP_WARM_POOL_SIZE=0`
 was the interim mitigation and is no longer needed.
+
+## 75. Verifier: Boolean wrappers bypass exactness; Greek claims crash — high/medium — DONE
+
+### What
+
+Two more soundness/robustness defects (external review, round 4).
+
+*Boolean provenance (high).* `_is_inexact` treats every `bool` as exact, and the
+comparison/predicate paths only inspected the collapsed value, so wrapping an
+inexact predicate re-earned an exact verdict:
+`(RR(1)+RR(1)/10^20-RR(1)).is_zero() == True` and
+`(lambda: (RR(1)+RR(1)/10^20-RR(1)).is_zero())()` were both
+`proved/exact_comparison`. Adding `== True` cannot increase certainty.
+
+*Unicode (medium).* The round-3 fix sliced operand substrings by AST column
+offset, but Python AST offsets count UTF-8 bytes while `str` slices count
+characters, so `α == α` extracted `'α '` / `''` and raised invalid syntax.
+
+### Fix
+
+- Exactness is judged from the claim's INPUTS, not its collapsed value:
+  `_exactness_probe_sources` returns every value-bearing sub-expression and the
+  ladder evaluates each, flagging any that is (or contains) a machine number.
+  The inexact leaf (`RR(1)`) is found inside a `== True`, a lambda body or a
+  predicate receiver alike. Exact claims are untouched (their sub-expressions
+  are exact), including exact predicates wrapped in `== True`.
+- `_is_inexact` no longer flags a value whose `parent()` is not a real number
+  ring: a symbolic function's `parent()` is its own class, whose `is_exact()`
+  raises, and the old `except: return True` called every `sin`/`cos`/`is_prime`
+  inexact. A no-parent or ring-less value is not a machine float.
+- `_comparison_sides` and `_exactness_probe_sources` use
+  `ast.get_source_segment`, which is character-correct (and keeps `^`), so Greek
+  and other non-ASCII claims survive.
+
+### How to verify
+
+`tests/test_verify.py`, real Sage: the `== True` and lambda wrappers are
+`supported/float_comparison`; `is_prime(7)`, `is_prime(7) == True`,
+`sin(x)^2 + cos(x)^2 == 1`, `sqrt(2) != 3/2`, `integral(sin(x)/x,x,0,oo)==pi/2`
+and `α == α` / `α^2 - 2*α + 1 == (α - 1)^2` are `proved`. 34 verify tests pass;
+`_comparison_sides`/`_exactness_probe_sources` unit tests cover the operator,
+the `^` substring, the Greek segment and the probe hit.
+
+### Status
+
+Fixed 2026-09-07; found by an external review at a3c6459. Builds on items 71/73.

--- a/REVIEW_ACTIONS.md
+++ b/REVIEW_ACTIONS.md
@@ -3902,3 +3902,46 @@ the `^` substring, the Greek segment and the probe hit.
 ### Status
 
 Fixed 2026-09-07; found by an external review at a3c6459. Builds on items 71/73.
+
+## 76. Warm-pool ceiling breaks when the reclaiming request is cancelled — medium — DONE
+
+### What
+
+The round-3 reclamation (item 74) ran the reclaimed worker's shutdown inline in
+the requesting coroutine: `get` did `await self._reclaim_refill(victim, spare)`.
+When that request was cancelled mid-cleanup -- `get("B")` cancelled while the
+worker was still shutting down -- the cleanup died with its waiter, the spare
+was never dropped from `_warm_in_flight`, and the worker stayed alive. A later
+`get("C")` then found the spare still counted but no reclamation making
+progress and started a third worker: three live processes for a ceiling of two.
+
+### Fix
+
+Reclamation is now MANAGER-owned, not waiter-owned, so it survives cancellation
+of whoever asked for it:
+
+- `_start_reclaim(task, spare)` cancels the refill and launches
+  `_reclaim_refill` as a tracked task in `_reclaim_tasks`, returning it.
+- `get` awaits that task through `asyncio.shield`, so a cancelled request stops
+  waiting but the cleanup runs on. Its spare stays in `_warm_in_flight` --
+  counted by admission -- until the process has actually exited.
+- The admission loop reclaims a live refill (`_warm_tasks`) or, when a
+  reclamation already owns the slot, waits on `_reclaim_tasks` rather than
+  overshooting. It loops only while something is reclaimable.
+- `shutdown` awaits `_reclaim_tasks` too, so it never returns over a worker an
+  owned reclamation is still tearing down.
+
+### How to verify
+
+`tests/test_warm_pool.py`, real worker subprocesses:
+`test_cancelling_the_reclaimer_mid_cleanup_does_not_overshoot` cancels `get("B")`
+while the reclaimed worker's shutdown is blocked, then admits `get("C")` and
+asserts C waits for the freed slot (no third worker) and the reclaimed worker
+exits. `test_shutdown_awaits_an_in_flight_reclamation` asserts `shutdown` blocks
+on an in-flight reclamation. 15 warm-pool tests pass; 100% coverage.
+
+### Status
+
+Fixed 2026-09-07; found by an external review at a3c6459. Completes item 74.
+`SAGEMATH_MCP_WARM_POOL_SIZE=0` remains the interim mitigation for conservative
+deployments and is not otherwise needed.

--- a/src/sagemath_mcp/session.py
+++ b/src/sagemath_mcp/session.py
@@ -760,6 +760,11 @@ class SageSessionManager:
         # worker it had already spawned, and so total-worker accounting can see
         # them before they reach `_warm_pool`.
         self._warm_in_flight: set[SageSession] = set()
+        # Manager-owned reclamations: shutting a cancelled refill's worker down
+        # is started here, not in the requesting task, so a caller cancelled
+        # mid-cleanup cannot orphan a live worker. Its spare stays reserved in
+        # `_warm_in_flight` until the process exits, and shutdown awaits these.
+        self._reclaim_tasks: set[asyncio.Task[None]] = set()
 
     @staticmethod
     def key_for(scope: str, name: str = DEFAULT_SESSION_NAME) -> str:
@@ -907,16 +912,26 @@ class SageSessionManager:
         self._warm_pool.append(spare)
         return True
 
-    async def _reclaim_refill(self, task: asyncio.Task[None], spare: SageSession) -> None:
-        """Cancel a refill and release its worker before its slot is reused.
+    def _start_reclaim(self, task: asyncio.Task[None], spare: SageSession) -> asyncio.Task[None]:
+        """Cancel a refill and hand its worker to a MANAGER-OWNED cleanup task.
 
-        Awaits the cancelled task, then shuts its spare down here -- in the
-        caller's uncancelled context, where the shutdown actually completes --
-        and only then drops it from `_warm_in_flight`. So the capacity a
-        replacement takes is genuinely free: the worker has exited, not merely
-        been signalled.
+        The cleanup is tracked in `_reclaim_tasks`, not run inline in the
+        requesting coroutine, so a caller cancelled while waiting for it cannot
+        abandon a live worker -- the earlier design ran the shutdown in the
+        waiter's task and leaked the process when that task was cancelled.
         """
         task.cancel()
+        cleanup = asyncio.ensure_future(self._reclaim_refill(task, spare))
+        self._reclaim_tasks.add(cleanup)
+        cleanup.add_done_callback(self._reclaim_tasks.discard)
+        return cleanup
+
+    async def _reclaim_refill(self, task: asyncio.Task[None], spare: SageSession) -> None:
+        """Await the cancelled refill, shut its worker down, then release the slot.
+
+        The spare stays in `_warm_in_flight` -- counted by admission -- until its
+        process has actually exited, so a replacement cannot start alongside it.
+        """
         with contextlib.suppress(BaseException):
             await asyncio.gather(task, return_exceptions=True)
         with contextlib.suppress(Exception):
@@ -932,7 +947,11 @@ class SageSessionManager:
         """
         target = max(0, self.settings.warm_pool_size)
         limit = self.settings.max_sessions
-        committed = len(self._sessions) + len(self._warm_pool) + len(self._warm_tasks)
+        # `_warm_in_flight` is the true reservation for the ceiling -- it holds a
+        # spare through warming AND reclamation, so a worker mid-cleanup still
+        # counts. The pool-target check uses live refills, since a reclaiming
+        # spare is on its way out and should not block a fresh one.
+        committed = len(self._sessions) + len(self._warm_pool) + len(self._warm_in_flight)
         if len(self._warm_pool) + len(self._warm_tasks) >= target:
             return
         if limit and committed >= limit:
@@ -975,18 +994,32 @@ class SageSessionManager:
                     # refill's slot first. Without this, `get` counted only
                     # `_sessions` while the refill counted its own slot, so a
                     # spare and a new session could both take the last slot and
-                    # overshoot max_sessions (CAP 2 LIVE 2 SPARES 1). Reclamation
-                    # AWAITS the worker's exit before the slot is reused, so the
-                    # replacement does not start alongside a still-live spare.
+                    # overshoot max_sessions (CAP 2 LIVE 2 SPARES 1). The
+                    # reservation (a spare in `_warm_in_flight`) is counted until
+                    # its process has EXITED, and reclamation is manager-owned and
+                    # shielded, so this waits for a genuinely free slot even if
+                    # this request is cancelled mid-cleanup -- the worker still
+                    # gets reclaimed and the slot is not double-counted.
+                    # Loop only while there is something to reclaim: a live refill
+                    # to cancel, or a reclamation already draining a slot. If the
+                    # ceiling is hit with neither, the session ceiling (checked
+                    # above) governs and there is nothing more to free here.
                     while (
                         limit
-                        and len(self._sessions) + len(self._warm_pool) + len(self._warm_tasks)
+                        and len(self._sessions) + len(self._warm_pool) + len(self._warm_in_flight)
                         >= limit
-                        and self._warm_tasks
+                        and (self._warm_tasks or self._reclaim_tasks)
                     ):
-                        victim, victim_spare = next(iter(self._warm_tasks.items()))
-                        del self._warm_tasks[victim]
-                        await self._reclaim_refill(victim, victim_spare)
+                        if self._warm_tasks:
+                            victim, victim_spare = next(iter(self._warm_tasks.items()))
+                            del self._warm_tasks[victim]
+                            await asyncio.shield(self._start_reclaim(victim, victim_spare))
+                        else:
+                            # A reclamation already owns the slot; wait for it to
+                            # free one rather than overshoot.
+                            await asyncio.shield(
+                                asyncio.gather(*self._reclaim_tasks, return_exceptions=True)
+                            )
                     session = SageSession(session_id, self.settings)
                     adopted = False
                 self._sessions[session_id] = session
@@ -1064,6 +1097,13 @@ class SageSessionManager:
         with contextlib.suppress(Exception):
             await asyncio.gather(*self._warm_tasks, return_exceptions=True)
         self._warm_tasks.clear()
+        # Await any manager-owned reclamations still in flight (a caller cancelled
+        # mid-cleanup handed its worker to one of these), so shutdown does not
+        # return while an owned worker is still being torn down.
+        if self._reclaim_tasks:
+            with contextlib.suppress(Exception):
+                await asyncio.gather(*self._reclaim_tasks, return_exceptions=True)
+        self._reclaim_tasks.clear()
         async with self._lock:
             sessions = list(self._sessions.values())
             self._sessions.clear()

--- a/src/sagemath_mcp/tools/verify.py
+++ b/src/sagemath_mcp/tools/verify.py
@@ -122,8 +122,8 @@ def _comparison_sides(claim: str) -> tuple[str | None, str | None, str | None]:
     evaluates to True by floating-point rounding; with the sides the ladder sees
     both live in an inexact field and refuses the exact verdict. Only a single
     comparison is handled (the truth-assembly gate guarantees at most one); a
-    bare predicate like `is_prime(7)` has no sides and is left to whole-claim
-    evaluation (its inputs are inspected via `_predicate_operand_sources`).
+    bare predicate like `is_prime(7)` has no sides and is evaluated whole. Either
+    way, exactness is judged from `_exactness_probe_sources`, not from this.
     """
     candidate = _EQUALS_NOT_COMPARISON.sub("==", claim)
     try:
@@ -133,49 +133,60 @@ def _comparison_sides(claim: str) -> tuple[str | None, str | None, str | None]:
     if isinstance(node, ast.Compare) and len(node.ops) == 1:
         op = _AST_COMPARE_OPS.get(type(node.ops[0]))
         if op is not None:
-            # Slice the ORIGINAL substrings, never ast.unparse: `^` is Python
+            # The ORIGINAL source of each side, never ast.unparse: `^` is Python
             # bit-xor (looser than +/-/*), so unparsing `x^2 - 2*x + 1` yields
-            # `x ^ (2 - 2*x + 1)` -- the wrong expression once Sage's preparser
-            # reads `^` as a power. The claim is whitespace-folded to one line,
-            # so column offsets index it directly.
+            # `x ^ (2 - 2*x + 1)`, the wrong expression once Sage's preparser
+            # reads `^` as a power. `get_source_segment`, not raw column slicing:
+            # AST offsets count UTF-8 bytes while `str` slices count characters,
+            # so a claim in Greek letters (two bytes per char) sliced mid-symbol.
             return (
-                candidate[node.left.col_offset : node.left.end_col_offset],
-                candidate[node.comparators[0].col_offset : node.comparators[0].end_col_offset],
+                ast.get_source_segment(candidate, node.left),
+                ast.get_source_segment(candidate, node.comparators[0]),
                 op,
             )
     return (None, None, None)
 
 
-def _predicate_operand_sources(claim: str) -> list[str]:
-    """Operand sources for a claim that is *not* a top-level comparison.
+def _exactness_probe_sources(claim: str) -> list[str]:
+    """Every value-bearing sub-expression of the claim, as source strings.
 
-    A bare predicate collapses to a Boolean that cannot reveal its own
-    provenance -- `(RR(1)+RR(1)/10^20-RR(1)).is_zero()` returns True by rounding,
-    with no comparison sides for the ladder to inspect, so it was proved exact.
-    The exactness check reads the predicate's inputs from the source instead: the
-    receiver and arguments of a top-level call (`X.is_zero()` -> `[X]`,
-    `is_prime(n)` -> `[n]`), otherwise the whole expression. Empty when the claim
-    IS a comparison -- that path already inspects its two sides.
+    Exactness is a property of a claim's INPUTS, and a Boolean result hides them:
+    `_is_inexact` can only see that the value is a `bool` and calls it exact, so
+    `(RR(1)+RR(1)/10^20-RR(1)).is_zero()` -- and, once a comparison collapses,
+    `... == True` or `(lambda: ...)()` -- were reported as exact proofs though
+    they rest on rounding. Adding `== True` cannot increase certainty.
+
+    So instead of trusting the collapsed value, the ladder evaluates each
+    sub-expression the claim is built from and asks whether any is (or contains)
+    a machine number. The inexact leaf (`RR(1)`) is a sub-expression of all three
+    cases above -- inside the receiver, inside the lambda body -- so it is found
+    regardless of how the Boolean was assembled. Exact claims are unaffected:
+    every sub-expression of `sin(x)^2 + cos(x)^2 == 1` is exact.
+
+    Sources come from `get_source_segment` (UTF-8-byte offsets vs character
+    slices, and `^` must not round-trip -- see `_comparison_sides`), deduplicated.
     """
     candidate = _EQUALS_NOT_COMPARISON.sub("==", claim)
     try:
-        node = ast.parse(candidate, mode="eval").body
+        tree = ast.parse(candidate, mode="eval")
     except SyntaxError:
         return []
-    def _src(sub: ast.AST) -> str:
-        # Original substring, not ast.unparse -- see _comparison_sides on why `^`
-        # cannot survive a round-trip through the Python AST.
-        return candidate[sub.col_offset : sub.end_col_offset]
-
-    if isinstance(node, ast.Compare):
-        return []
-    if isinstance(node, ast.Call):
-        sources: list[str] = []
-        if isinstance(node.func, ast.Attribute):
-            sources.append(_src(node.func.value))
-        sources.extend(_src(a) for a in node.args if not isinstance(a, ast.Starred))
-        return sources or [_src(node)]
-    return [_src(node)]
+    # Value expressions that can introduce or carry a number. Booleans
+    # (`ast.BoolOp`) are excluded as containers -- their operands are visited on
+    # their own -- and names/constants are cheap to re-check.
+    value_nodes = (
+        ast.Call, ast.Attribute, ast.BinOp, ast.UnaryOp, ast.Subscript,
+        ast.Name, ast.Constant, ast.List, ast.Tuple, ast.Set, ast.Dict,
+    )
+    sources: list[str] = []
+    seen: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, value_nodes):
+            segment = ast.get_source_segment(candidate, node)
+            if segment and segment not in seen:
+                seen.add(segment)
+                sources.append(segment)
+    return sources
 
 
 def _reject_truth_assembly(claim: str) -> None:
@@ -296,11 +307,11 @@ async def verify_claim(
     lhs_literal = _encode_literal(lhs_src) if have_sides else "None"
     rhs_literal = _encode_literal(rhs_src) if have_sides else "None"
     op_literal = _encode_literal(op_src) if have_sides else "None"
-    # For a bare predicate (no top-level comparison), the values to check for
-    # exactness are the predicate's own operands, read from the source -- the
-    # collapsed Boolean cannot reveal them. Encoded as literals like the sides.
-    operand_srcs = _predicate_operand_sources(claim)
-    operand_srcs_literal = "[" + ", ".join(_encode_literal(s) for s in operand_srcs) + "]"
+    # Exactness is judged from the claim's inputs, not its collapsed value: every
+    # value-bearing sub-expression is evaluated and checked, so a machine number
+    # hidden inside a Boolean (a predicate, `== True`, a lambda) is still found.
+    probe_srcs = _exactness_probe_sources(claim)
+    probe_srcs_literal = "[" + ", ".join(_encode_literal(s) for s in probe_srcs) + "]"
     code = (
         _sage_prelude()
         + textwrap.dedent(
@@ -309,7 +320,7 @@ async def verify_claim(
         _lhs_src = {lhs_literal}
         _rhs_src = {rhs_literal}
         _op_src = {op_literal}
-        _operand_srcs = {operand_srcs_literal}
+        _probe_srcs = {probe_srcs_literal}
         _nsamples = {int(samples)}
         _prec = {int(precision_bits)}
         # When the claim is a single comparison, evaluate each side EXACTLY ONCE
@@ -392,13 +403,20 @@ async def verify_claim(
             try:
                 _p = _v.parent()
             except AttributeError:
-                return True  # unknown provenance -> qualify, never prove
+                # No parent and not a Python number or container: a function, a
+                # module, a symbolic constant, a string -- none of which is a
+                # machine float. (An inexact NUMBER always has a parent whose
+                # ring answers is_exact(), or is a Python float caught above.)
+                return False
             if _p is SR:
                 return _symbolic_is_inexact(_v)
             try:
                 return not _p.is_exact()
             except Exception:
-                return True
+                # `parent()` did not return a ring with a usable `is_exact()`
+                # (a symbolic function's parent is its own class, for instance).
+                # That is not a machine-number field, so the value is not inexact.
+                return False
         def _domain_holds(_dom, _val):
             # Does a rational sample value lie in a declared domain?
             try:
@@ -451,28 +469,22 @@ async def verify_claim(
                 except Exception:
                     return False
             return True
+        # Exactness is judged from the claim's INPUTS, not its collapsed value: a
+        # Boolean's type says nothing about how it was produced, so
+        # `(...).is_zero()`, `... == True` and `(lambda: ...)()` all hid their
+        # rounding. Evaluate every value-bearing sub-expression and flag any that
+        # is (or contains) a machine number; the inexact leaf is found wherever
+        # it sits. A sub-expression that cannot be evaluated on its own (a
+        # comprehension target, a lambda parameter) is skipped -- it says nothing
+        # about exactness -- rather than qualifying every claim that has one.
         _inexact_operands = False
-        try:
-            if _lhs_src is not None:
-                # A comparison: inspect the retained side values, the very ones
-                # the relation above was built from -- not a second evaluation
-                # of the source.
-                _inexact_operands = _is_inexact(_lhs_v) or _is_inexact(_rhs_v)
-            elif isinstance(_claim, bool):
-                # A bare predicate (no comparison sides). The collapsed Boolean
-                # cannot reveal its provenance, so inspect the predicate's own
-                # operands, read from the source. No operands to check (an opaque
-                # predicate) is itself unestablished provenance -> qualify.
-                if _operand_srcs:
-                    _inexact_operands = any(
-                        _is_inexact(sage_eval(_s, locals=_locals)) for _s in _operand_srcs
-                    )
-                else:
+        for _s in _probe_srcs:
+            try:
+                if _is_inexact(sage_eval(_s, locals=_locals)):
                     _inexact_operands = True
-            elif hasattr(_claim, 'is_relational') and _claim.is_relational():
-                _inexact_operands = _is_inexact(_claim.lhs()) or _is_inexact(_claim.rhs())
-        except Exception:
-            _inexact_operands = True  # cannot establish exactness -> qualify, never prove
+                    break
+            except Exception:
+                continue
         _verdict = None
         _method = None
         _evidence = None

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -128,7 +128,7 @@ async def test_verify_claim_reads_decimal_literals_exactly(claim, expected, monk
 
 
 def test_comparison_sides_splits_a_single_comparison():
-    from sagemath_mcp.tools.verify import _comparison_sides, _predicate_operand_sources
+    from sagemath_mcp.tools.verify import _comparison_sides, _exactness_probe_sources
 
     assert _comparison_sides("RR(1) == RR(2)") == ("RR(1)", "RR(2)", "==")
     # The equation spelling is normalized before splitting, and the sides keep
@@ -137,12 +137,20 @@ def test_comparison_sides_splits_a_single_comparison():
     lhs, rhs, op = _comparison_sides("x^2 - 1 = 0")
     assert lhs.replace(" ", "") == "x^2-1" and rhs == "0" and op == "=="
     assert _comparison_sides("e^pi != pi^e") == ("e^pi", "pi^e", "!=")
-    # A bare predicate has no comparison sides; its operands are read instead.
+    # Greek letters: get_source_segment must return whole symbols, not a slice
+    # cut mid-character by a byte offset (each letter is two UTF-8 bytes).
+    alpha = chr(0x3B1)  # built from its code point so no ambiguous literal is in the source
+    assert _comparison_sides(f"{alpha} == {alpha}") == (alpha, alpha, "==")
+    # A bare predicate has no comparison sides; whole-claim evaluation.
     assert _comparison_sides("is_prime(7)") == (None, None, None)
-    assert _predicate_operand_sources("is_prime(7)") == ["7"]
-    assert _predicate_operand_sources("(RR(1)+RR(1)/10^20).is_zero()") == [
-        "RR(1)+RR(1)/10^20"
-    ]
+    # The exactness probe surfaces the inexact input wherever it hides -- inside
+    # a predicate receiver, a `== True` wrapper, or a zero-arg lambda body.
+    for claim in (
+        "(RR(1)+RR(1)/10^20-RR(1)).is_zero() == True",
+        "(lambda: (RR(1)+RR(1)/10^20-RR(1)).is_zero())()",
+    ):
+        assert any("RR(1)" in s for s in _exactness_probe_sources(claim))
+    assert _exactness_probe_sources(alpha) == [alpha]  # UTF-8 handled here too
     # A comparison whose operator is not one of the six ordering/equality ops
     # (membership, identity) has no proof-grade sides: whole-claim evaluation.
     assert _comparison_sides("x in (1, 2, 3)") == (None, None, None)
@@ -423,5 +431,33 @@ async def test_verify_claim_ladder_against_real_sage(monkeypatch):
         assert (await server.verify_claim("is_prime(7)", ctx=ctx)).verdict == "proved"
         power = await server.verify_claim("x^2 - 2*x + 1 = (x - 1)^2", ctx=ctx)
         assert power.verdict == "proved"
+
+        # External-review round 4: a Boolean's type must not establish exactness.
+        # Wrapping the inexact predicate in `== True` or a zero-argument lambda
+        # kept the rounding but was reported proved; exactness is now read from
+        # the sub-expressions, so both qualify while their exact counterparts do
+        # not.
+        boolean_wrap = await server.verify_claim(
+            "(RR(1)+RR(1)/10^20-RR(1)).is_zero() == True", ctx=ctx
+        )
+        assert boolean_wrap.verdict == "supported"
+        assert boolean_wrap.method == "float_comparison"
+        lambda_wrap = await server.verify_claim(
+            "(lambda: (RR(1)+RR(1)/10^20-RR(1)).is_zero())()", ctx=ctx
+        )
+        assert lambda_wrap.verdict == "supported"
+        # `== True` on an EXACT predicate cannot lower certainty either -- it is
+        # still proved, and the probe does not false-positive on function names.
+        assert (await server.verify_claim("is_prime(7) == True", ctx=ctx)).verdict == "proved"
+
+        # External-review round 4: Greek-symbol claims. AST column offsets count
+        # UTF-8 bytes, so the old raw slicing cut a two-byte letter in half and
+        # produced invalid syntax; get_source_segment keeps the whole symbol.
+        alpha = chr(0x3B1)
+        assert (await server.verify_claim(f"{alpha} == {alpha}", ctx=ctx)).verdict == "proved"
+        greek = await server.verify_claim(
+            f"{alpha}^2 - 2*{alpha} + 1 == ({alpha} - 1)^2", ctx=ctx
+        )
+        assert greek.verdict == "proved"
     finally:
         await manager.shutdown()

--- a/tests/test_warm_pool.py
+++ b/tests/test_warm_pool.py
@@ -10,6 +10,7 @@ so "warm" is fast, but the pool mechanics are the same.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 
 from sagemath_mcp.config import SageSettings
 from sagemath_mcp.session import _WARM_SPARE_ID, SageProcessError, SageSession, SageSessionManager
@@ -263,4 +264,121 @@ async def test_reclaim_awaits_the_worker_exit_before_reusing_the_slot(monkeypatc
         live = [s for s in manager._sessions.values() if s.is_alive()]
         assert len(live) <= 2
     finally:
+        await manager.shutdown()
+
+
+async def test_cancelling_the_reclaimer_mid_cleanup_does_not_overshoot(monkeypatch):
+    """Cancellation of the reclaiming waiter (external review, round 4).
+
+    B triggers reclamation of an in-flight spare and is cancelled while that
+    spare is still shutting down; C then asks for a workspace. Reclamation is
+    manager-owned and its reservation is held (counted) until the process exits,
+    so C waits for the freed slot instead of overshooting the ceiling.
+    """
+    manager = SageSessionManager(_settings(max_sessions=2, warm_pool_size=1))
+    warming = asyncio.Event()
+    shutting = asyncio.Event()
+    release_shutdown = asyncio.Event()
+    real_eval = SageSession.evaluate
+    real_shutdown = SageSession.shutdown
+
+    async def blocking_eval(self, *args, **kwargs):
+        if self.session_id == _WARM_SPARE_ID and not warming.is_set():
+            warming.set()
+            await asyncio.Event().wait()  # hold the refill spare warming until reclaimed
+        return await real_eval(self, *args, **kwargs)
+
+    async def blocking_shutdown(self):
+        if self.session_id == _WARM_SPARE_ID and not release_shutdown.is_set():
+            shutting.set()
+            await release_shutdown.wait()  # hold the reclamation mid-cleanup
+        return await real_shutdown(self)
+
+    try:
+        await manager.warm_up()  # W0 pooled (unpatched, so its warm-up completes)
+        # Patch AFTER warm_up so only the *refill* spare (W1) blocks.
+        monkeypatch.setattr(SageSession, "evaluate", blocking_eval)
+        monkeypatch.setattr(SageSession, "shutdown", blocking_shutdown)
+
+        await manager.get("A")  # adopts W0, schedules W1 (its warm eval blocks)
+        await asyncio.wait_for(warming.wait(), 3)
+        assert len(manager._warm_in_flight) == 1
+        w1 = next(iter(manager._warm_in_flight))
+
+        # B reclaims W1; cancel B while W1's shutdown (the cleanup) is blocked.
+        b = asyncio.create_task(manager.get("B"))
+        await asyncio.wait_for(shutting.wait(), 3)
+        b.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await b
+
+        # C must wait for the manager-owned reclamation, not start a third worker.
+        c = asyncio.create_task(manager.get("C"))
+        await asyncio.sleep(0.1)
+        assert not c.done(), "C proceeded before the reclaimed worker's slot was freed"
+        release_shutdown.set()
+        await asyncio.wait_for(c, 5)
+
+        assert not w1.is_alive(), "the reclaimed worker survived a cancelled reclaimer"
+        assert not manager._warm_in_flight
+        live = [s for s in manager._sessions.values() if s.is_alive()]
+        assert len(live) <= 2, f"overshoot: {len(live)} live workers for a ceiling of 2"
+    finally:
+        release_shutdown.set()
+        await manager.shutdown()
+
+
+async def test_shutdown_awaits_an_in_flight_reclamation(monkeypatch):
+    """Shutdown must not return while a manager-owned reclamation is still tearing
+    a worker down (external review, round 4).
+
+    A refill's reclaimer is cancelled mid-cleanup, leaving the shutdown of its
+    worker owned by ``_reclaim_tasks``. ``manager.shutdown()`` has to await that
+    cleanup so it does not return over a still-live worker.
+    """
+    manager = SageSessionManager(_settings(max_sessions=2, warm_pool_size=1))
+    warming = asyncio.Event()
+    shutting = asyncio.Event()
+    release_shutdown = asyncio.Event()
+    real_eval = SageSession.evaluate
+    real_shutdown = SageSession.shutdown
+
+    async def blocking_eval(self, *args, **kwargs):
+        if self.session_id == _WARM_SPARE_ID and not warming.is_set():
+            warming.set()
+            await asyncio.Event().wait()
+        return await real_eval(self, *args, **kwargs)
+
+    async def blocking_shutdown(self):
+        if self.session_id == _WARM_SPARE_ID and not release_shutdown.is_set():
+            shutting.set()
+            await release_shutdown.wait()
+        return await real_shutdown(self)
+
+    try:
+        await manager.warm_up()
+        monkeypatch.setattr(SageSession, "evaluate", blocking_eval)
+        monkeypatch.setattr(SageSession, "shutdown", blocking_shutdown)
+
+        await manager.get("A")  # schedules the refill whose warm eval blocks
+        await asyncio.wait_for(warming.wait(), 3)
+        w1 = next(iter(manager._warm_in_flight))
+
+        b = asyncio.create_task(manager.get("B"))  # reclaims the refill
+        await asyncio.wait_for(shutting.wait(), 3)
+        b.cancel()  # reclamation becomes manager-owned, still mid-cleanup
+        with contextlib.suppress(asyncio.CancelledError):
+            await b
+        assert manager._reclaim_tasks
+
+        sd = asyncio.create_task(manager.shutdown())
+        await asyncio.sleep(0.1)
+        assert not sd.done(), "shutdown returned while a reclamation was still in flight"
+        release_shutdown.set()
+        await asyncio.wait_for(sd, 5)
+
+        assert not w1.is_alive()
+        assert not manager._reclaim_tasks
+    finally:
+        release_shutdown.set()
         await manager.shutdown()


### PR DESCRIPTION
## Round-4 external review response

Fixes the three findings the reviewer reproduced at `a3c6459`. Each is written
test-first against real Sage / real worker subprocesses and recorded in
`REVIEW_ACTIONS.md` (items 75–76).

### 1. Verifier: Boolean wrappers bypassed exactness (High) — item 75
`(RR(1)+RR(1)/10^20-RR(1)).is_zero() == True` and the same predicate in a lambda
both earned `proved/exact_comparison` — a machine-float computation re-certified
as exact merely by collapsing to a `bool`. Exactness is now judged from the
claim's **inputs**: `_exactness_probe_sources` walks every value-bearing
sub-expression and the ladder flags any that is (or contains) a machine number,
so the inexact `RR(1)` leaf is found inside `== True`, a lambda body, or a
predicate receiver alike. Exact claims (including exact predicates wrapped in
`== True`) are untouched.

### 2. Verifier: Greek-symbol claims crashed (Medium) — item 75
Round-3 sliced operand substrings by AST column offset, but Python AST offsets
count UTF-8 bytes while `str` slices count characters, so `α == α` raised invalid
syntax. `_comparison_sides` / `_exactness_probe_sources` now use
`ast.get_source_segment` (character-correct, and preserves `^`).

### 3. Warm-pool ceiling broke when the reclaiming request was cancelled (Medium) — item 76
Reclamation ran inline in the requesting coroutine, so a request cancelled
mid-cleanup killed the cleanup with its waiter: the spare stayed counted, its
worker stayed alive, and a later admission started a third worker for a ceiling
of two. Reclamation is now **manager-owned** — `_start_reclaim` tracks the
cleanup in `_reclaim_tasks`, `get` awaits it through `asyncio.shield` (a cancelled
requester stops waiting; the cleanup runs on), the spare stays reserved in
`_warm_in_flight` until its process exits, and `shutdown` awaits `_reclaim_tasks`.
Adds the reviewer's exact sequence (cancel B during cleanup, then admit C) plus a
shutdown-awaits-reclamation test.

## Verification
- 1026 pure-Python tests pass; **100% statement + branch coverage**.
- 34 verifier tests and 15 warm-pool tests pass (verifier ladder cases confirmed
  against real Sage).
- `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYaDocYYsXJGbSqv7vb3Ns
