### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-09-07
+
 A survey of the other SageMath MCP servers (a feature comparison and a
-code-level read of each peer's source, 2026-08-24) drove this window. Nothing
-here is a breaking change.
+code-level read of each peer's source, 2026-08-24) drove this window, and four
+rounds of external review hardened it. Nothing here is a breaking change: the
+40-tool surface, the deny-by-default sandbox and the stdio/HTTP transports are
+unchanged; everything added is additive (the `verify_claim` tool, MCP prompts,
+the pre-warmed worker pool, portable workspace handles, image plot responses,
+mutation and property testing, an outcome benchmark, and the opt-in passagemath
+runtime). Highlights: `verify_claim` for checking the model's own algebra;
+`pip install "sagemath-mcp[passagemath]"` as a ~1 GB alternative to the 3 GB
+Sage image; and plots that render as images instead of a base64 wall.
 
 ### Added
 
@@ -255,6 +264,29 @@ here is a breaking change.
   `set_verbose` (installed into the worker namespace after the scrub); both are
   meant to be absent, and three tests enforce it. The generator now subtracts the
   shims.
+- **Workspace tokens no longer leak into logs** (2026-09-07 external review,
+  REVIEW_ACTIONS 70). `reset`/`interrupt`/`cancel`/`stop` interpolated the
+  caller's `session` argument — now a bearer `workspace_token` — into MCP
+  notifications and responses, contrary to the secrecy the handle promises. A
+  token is shown as the generic label `the workspace`; only names appear.
+- **`verify_claim` enforces exactness on every proof path** (2026-09-07
+  external review, REVIEW_ACTIONS 71, 73, 75). A rounded result wrapped in a
+  list, a symbolic expression, a dict key, a bare predicate
+  (`(RR(1)+RR(1)/10^20-RR(1)).is_zero()`), or that predicate wrapped in `== True`
+  or a lambda, was still reported `proved/exact`. Exactness is now judged from a
+  claim's inputs, not its collapsed value: every value-bearing sub-expression is
+  evaluated from its original source (so Python's bit-xor precedence for `^`, and
+  UTF-8-byte-vs-character offsets for non-ASCII like `α`, can neither corrupt nor
+  crash a claim) and any machine number among them blocks an exact rung. The
+  session's active assumptions are attached centrally — a structured
+  `assumptions` field and the evidence — so no branch can conceal them.
+- **Warm pool holds its ceiling and reclaims cancelled workers** (2026-09-07
+  external review, REVIEW_ACTIONS 72, 74, 76). Total-worker accounting (live
+  sessions + pool + in-flight refills) is shared, so a refill can no longer
+  overshoot `SAGEMATH_MCP_MAX_SESSIONS`; and a cancelled refill's worker is
+  reclaimed to completion by a manager-owned cleanup that survives cancellation
+  of the request that triggered it — rather than being dropped from tracking
+  while still alive — before its slot is reused.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -1461,6 +1461,30 @@ sagemath-mcp/
 Every released version, newest first. [`CHANGELOG.md`](CHANGELOG.md) carries the
 full detail; this is the shape of each release.
 
+### v0.7.0 (2026-09-07)
+
+The 2026-08-24 field survey and four rounds of external review. All additive —
+no breaking changes.
+
+**Added**
+
+- **`verify_claim`** — re-checks a stated claim through a proof ladder (symbolic
+  prover, exact difference, exact algebraic arithmetic, certified intervals,
+  numeric sampling), reporting `proved`/`refuted`/`supported`/`undecided` with
+  evidence. Exactness is a prerequisite for a proof, and active assumptions are
+  named in the result.
+- **passagemath runtime** (`pip install "sagemath-mcp[passagemath]"`) — an
+  experimental ~1 GB pip alternative to the 3 GB Sage image; both runtimes work,
+  the security artifact set is chosen at import.
+- **MCP prompts, a pre-warmed worker pool, portable workspace handles, image
+  plot responses, mutation + property testing, and an outcome benchmark.**
+
+**Fixed**
+
+- Plots return MCP image content; non-finite results stay valid JSON; workspace
+  tokens are kept out of logs; the release validates the image it publishes; and
+  a run of verifier-soundness and warm-pool-lifecycle hardening from review.
+
 ### v0.6.1 (2026-08-16)
 
 A security patch on 0.6.0.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This document tracks planned improvements to the SageMath MCP server, organized by priority and effort. The goal is to strengthen the server's position as a universal mathematics MCP server that enables LLMs to perform any symbolic or discrete mathematical operation.
 
-**Current state (last release v0.6.1; the work below is on `main`, unreleased):**
+**Current state (last release v0.7.0; the work below is on `main`, unreleased):**
 40 MCP tools (33 Sage-backed, 7 infrastructure) covering calculus, algebra,
 linear algebra, ODEs, number theory, combinatorics, graph theory, group theory,
 elliptic curves, coding theory, boolean algebra, polynomial rings, geometry,

--- a/charts/sagemath-mcp/Chart.yaml
+++ b/charts/sagemath-mcp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sagemath-mcp
 description: A Helm chart for deploying the SageMath MCP server.
 type: application
-version: 0.6.1
-appVersion: "0.6.1"
+version: 0.7.0
+appVersion: "0.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sagemath-mcp"
-version = "0.6.1"
+version = "0.7.0"
 description = "Model Context Protocol server that provides stateful SageMath computations."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.XBP-Europe/sagemath-mcp",
   "title": "SageMath",
   "description": "Stateful SageMath MCP server with 40 tools and a sandboxed Sage session per client.",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "websiteUrl": "https://github.com/XBP-Europe/sagemath-mcp",
   "repository": {
     "url": "https://github.com/XBP-Europe/sagemath-mcp",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "sagemath-mcp",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/sagemath_mcp/__init__.py
+++ b/src/sagemath_mcp/__init__.py
@@ -5,5 +5,5 @@ from importlib.metadata import PackageNotFoundError, version
 try:  # pragma: no cover - executed during packaging only
     __version__ = version("sagemath-mcp")
 except PackageNotFoundError:  # pragma: no cover - local dev fallback
-    __version__ = "0.6.1"
+    __version__ = "0.7.0"
 __all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -5075,7 +5075,7 @@ wheels = [
 
 [[package]]
 name = "sagemath-mcp"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Release 0.7.0

Re-prepared on top of the round-4 review fixes (PR #74, merged). Supersedes the
held PR #72.

Bumps `0.6.1 → 0.7.0` across `pyproject.toml`, `src/sagemath_mcp/__init__.py`,
`charts/sagemath-mcp/Chart.yaml`, `server.json` and `uv.lock`; converts
`CHANGELOG.md` `[Unreleased] → [0.7.0] - 2026-09-07`; adds the v0.7.0
release-history entry to `README.md`; rolls `ROADMAP.md`'s "last release" to
0.7.0.

### What's in 0.7.0

Driven by the 2026-08-24 field survey and **four rounds of external review**.
All additive — the 40-tool surface, the deny-by-default sandbox and the
stdio/HTTP transports are unchanged.

**Added**
- `verify_claim` — a proof ladder (symbolic prover, exact difference, exact
  algebraic, certified interval, numeric sampling) reporting
  `proved`/`refuted`/`supported`/`undecided` with evidence; exactness is a
  prerequisite for a proof.
- **passagemath runtime** — `pip install "sagemath-mcp[passagemath]"`, a ~1 GB
  pip alternative to the 3 GB Sage image; both runtimes work, artifacts chosen
  at import.
- MCP prompts (3), a pre-warmed worker pool, portable workspace handles, image
  plot responses, mutation + property testing, and an outcome benchmark.

**Fixed (review hardening)**
- Workspace tokens kept out of logs (REVIEW_ACTIONS 70).
- `verify_claim` exactness enforced from a claim's inputs — Boolean/lambda
  wrappers, `^` precedence and non-ASCII (`α`) all handled (71/73/75).
- Warm pool holds its ceiling; a cancelled refill's worker is reclaimed by a
  manager-owned cleanup that survives cancellation of the requester (72/74/76).
- Plots return MCP image content; non-finite results stay valid JSON; the
  release validates the image it publishes.

### Verification
- 1026 pure-Python tests, **100% statement + branch coverage**; `ruff` clean;
  version-consistency tests pass. Integration + smoke were green on the
  underlying code via #74.

### Release mechanics
Merging this does **not** publish. Tagging `v0.7.0` triggers `release.yml`
(tests on 3.12/3.13, wheel/sdist, signed GHCR image, PyPI, MCP registry) — each
publish gated on the tag **push** event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYaDocYYsXJGbSqv7vb3Ns
