### PR TITLE
Add optional HTTP bearer-token authentication (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Optional HTTP bearer-token authentication (opt-in).** Set
+  `SAGEMATH_MCP_HTTP_AUTH_TOKEN=<secret>` and every MCP request over the HTTP
+  transports must carry `Authorization: Bearer <secret>`; the `/health` and
+  `/ready` probes stay open for load balancers. The token is compared in constant
+  time (`secrets.compare_digest`) and never logged. No-auth stays the deliberate
+  default — the container is the boundary, keep it on loopback (`SECURITY.md`) —
+  and the server now logs a loud warning when it binds a non-loopback host with
+  no token set, so the Dockerfile's container-internal `--host 0.0.0.0` is an
+  explicit, noted choice. It is a single shared secret (an API key, not an OAuth
+  server) that guards the transport, not a replacement for the container or TLS.
+  See `src/sagemath_mcp/auth.py` and `tests/test_auth.py`.
 - **passagemath CI lane and pin smoke gate.** A `passagemath` job in `ci.yml`
   cold-installs the exact `passagemath-standard==10.8.9` pin (no Docker, ~1 min)
   and runs the whole test suite against it — the real worker, the artifact-drift

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,12 @@ USER sage
 EXPOSE 8314
 
 ENTRYPOINT ["sage", "-python", "-m", "sagemath_mcp.server"]
+# `--host 0.0.0.0` binds every interface INSIDE the container's own network
+# namespace -- correct here, because who can reach the server is decided by how
+# the port is published (the docs publish it on 127.0.0.1). It is not a bind on
+# your host. The server has no authentication by default, so do not publish this
+# port to a network without either putting an authenticating proxy in front or
+# setting SAGEMATH_MCP_HTTP_AUTH_TOKEN=<secret> to require a bearer token (see
+# SECURITY.md); the server logs a warning if it binds a non-loopback host with
+# neither.
 CMD ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8314"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,8 +40,19 @@ even if you cannot yet build a payload from it.
 The practical consequence: **run the container, and do not expose the port.**
 Defaults are loopback throughout — stdio transport, `--host 127.0.0.1`, the
 compose file publishing to `127.0.0.1:8314`, a `ClusterIP` service — because
-there is **no authentication**, which is normal for a locally-run MCP server and
-is why it must stay local unless you put something authenticating in front.
+there is **no authentication by default**, which is normal for a locally-run MCP
+server and is why it must stay local unless you put something authenticating in
+front.
+
+**Optional bearer-token auth (opt-in).** For anyone who does front the HTTP
+endpoint, setting `SAGEMATH_MCP_HTTP_AUTH_TOKEN=<secret>` requires every MCP
+request to carry `Authorization: Bearer <secret>`, compared in constant time and
+never logged; the `/health` and `/ready` probes stay open for load balancers. It
+is a single shared secret — an API key, not an OAuth server, with no rotation,
+scopes or per-user identity — and it guards the **transport**, not the process:
+it does not replace the container boundary or TLS, which a real deployment still
+fronts. It is off unless set, and the server logs a warning when it binds a
+non-loopback host with no token.
 
 **Workspace handles are bearer credentials, not authentication.** A
 `workspace_token` from `start_sage_session` grants access to that one workspace
@@ -141,7 +152,8 @@ crosses a trust boundary.
   not outbound access.
 - Authentication, TLS, tenant authorization and audit retention are supplied by
   the surrounding platform when this becomes a shared or remotely reachable
-  service.
+  service. The optional `SAGEMATH_MCP_HTTP_AUTH_TOKEN` bearer token is a single
+  shared secret for the transport, not a substitute for that platform.
 - The documented image and Sage version are used. A Sage upgrade can add new
   helpers or change namespace provenance and must rerun the full security and
   integration suites before release.

--- a/TODO.md
+++ b/TODO.md
@@ -152,11 +152,18 @@ prioritised. Correctness first, then packaging/adoption.
       reconstruction accepts `inf`/`nan`, non-finite floats travel as strings.
       Everything else already sound (large ints → decimal strings, plots → image
       content, plain strings fine). `tests/test_codegen.py`.
-- [ ] **Optional HTTP auth.** The posture (SECURITY.md: no auth, the container
-      is the boundary, keep it loopback) is deliberate and stays the default,
-      but an optional bearer-token FastMCP auth provider — and making the
-      Dockerfile's `0.0.0.0` bind an explicit, loudly-noted opt-in — is a fair
-      refinement for anyone fronting it. Not a blocker; a deliberate opt-in.
+- [x] **Optional HTTP auth.** *Done, 2026-09-07.* No-auth stays the deliberate
+      default (SECURITY.md: the container is the boundary, keep it loopback). On
+      top of it, `SAGEMATH_MCP_HTTP_AUTH_TOKEN=<secret>` now requires
+      `Authorization: Bearer <secret>` on every MCP request over HTTP — a
+      constant-time-compared (`secrets.compare_digest`), never-logged shared
+      secret via a `TokenVerifier` provider (`auth.py`, wired through
+      `app.py`); `/health` and `/ready` stay open. Verified end-to-end against the
+      ASGI app (open probe 200; `/mcp` 401 without/with a wrong token, 200 with
+      the right one). The Dockerfile's container-internal `--host 0.0.0.0` is now
+      an explicit, noted choice: the server logs a loud warning when it binds a
+      non-loopback host with no token (`_exposure_warning`). `tests/test_auth.py`,
+      SECURITY.md, USAGE.md.
 - [x] **Mutation-test the security policy.** *Done, 2026-09-06.* `make mutation`
       (`scripts/run_mutation_tests.py`) runs cosmic-ray over `security.py`, plus
       Hypothesis property tests (`tests/test_security_property.py`) on top of the

--- a/USAGE.md
+++ b/USAGE.md
@@ -43,10 +43,30 @@ sage -python -m uv run sagemath-mcp --transport streamable-http --host 0.0.0.0 -
 ```
 > `--host 0.0.0.0` is correct **inside a container**, where it means "listen on
 > the container's interfaces" and the published port decides who can reach it.
-> Do not use it on a host: the server evaluates code and has no authentication,
-> so binding every interface exposes an unauthenticated evaluator to the network.
-> The bundled compose file publishes to `127.0.0.1` for the same reason.
+> Do not use it on a host: the server evaluates code and has no authentication
+> by default, so binding every interface exposes an unauthenticated evaluator to
+> the network. The bundled compose file publishes to `127.0.0.1` for the same
+> reason.
 The server advertises its MCP endpoint at `http://HOST:PORT/mcp`.
+
+#### Optional bearer-token authentication
+
+No auth is the deliberate default (the container is the boundary — see
+[SECURITY.md](SECURITY.md)). If you front the HTTP endpoint on a network, set a
+shared secret and every MCP request must then present it:
+
+```bash
+export SAGEMATH_MCP_HTTP_AUTH_TOKEN="$(openssl rand -hex 32)"
+uv run sagemath-mcp --transport streamable-http --host 0.0.0.0 --port 8314
+# clients send:  Authorization: Bearer <that token>
+```
+
+The token is compared in constant time and never logged. The `/health` and
+`/ready` probes stay open so a load balancer can reach them. It is a single
+shared secret — an API key, not an OAuth server, and not a substitute for the
+container boundary or TLS. Leave `SAGEMATH_MCP_HTTP_AUTH_TOKEN` unset to keep the
+endpoint open; the server logs a warning if it binds a non-loopback host with no
+token.
 
 ## Available Tools & Resources (40 tools, 3 resources)
 

--- a/src/sagemath_mcp/app.py
+++ b/src/sagemath_mcp/app.py
@@ -28,6 +28,7 @@ from fastmcp.server.middleware.logging import LoggingMiddleware
 from fastmcp.server.middleware.timing import TimingMiddleware
 
 from . import __version__, runtime
+from .auth import build_http_auth
 
 LOGGER = logging.getLogger(__name__)
 
@@ -105,6 +106,10 @@ mcp = FastMCP(
     instructions=MCP_INSTRUCTIONS,
     version=__version__,
     lifespan=_lifespan,
+    # None unless SAGEMATH_MCP_HTTP_AUTH_TOKEN is set, so the app is
+    # unauthenticated by default (SECURITY.md). When set, it guards the MCP
+    # endpoint over HTTP; stdio and the /health, /ready probes are unaffected.
+    auth=build_http_auth(runtime.SETTINGS),
 )
 mcp.add_middleware(TimingMiddleware())
 mcp.add_middleware(

--- a/src/sagemath_mcp/auth.py
+++ b/src/sagemath_mcp/auth.py
@@ -1,0 +1,61 @@
+"""Optional bearer-token authentication for the HTTP transports.
+
+Opt-in only. The default posture is unchanged and deliberate (see SECURITY.md):
+no authentication, the container is the boundary, keep the endpoint on loopback.
+This adds one thing on top for anyone who fronts the HTTP endpoint on a network:
+a single operator-configured bearer token, set through
+``SAGEMATH_MCP_HTTP_AUTH_TOKEN``. When it is set, every MCP request must carry
+``Authorization: Bearer <token>``; when it is not, nothing changes.
+
+It is a shared-secret API key, not an OAuth server: no rotation, scopes, expiry
+or per-user identity. It is defence for the transport, not a replacement for the
+container -- a pip install still runs with your user's privileges. The token is
+compared in constant time so a wrong guess cannot be recovered byte by byte from
+response timing, and it is never logged.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+from fastmcp.server.auth import AccessToken, AuthProvider, TokenVerifier
+
+from .config import SageSettings
+
+# A fixed identity for the single shared token. There is exactly one principal,
+# so the id is a label, not a secret, and it never carries the token itself.
+_CLIENT_ID = "sagemath-mcp-bearer"
+
+
+class StaticBearerTokenVerifier(TokenVerifier):
+    """Accepts exactly one operator-configured bearer token, in constant time."""
+
+    def __init__(self, token: str) -> None:
+        if not token:
+            raise ValueError("bearer token must be a non-empty string")
+        super().__init__()
+        # Keep the expected value as bytes: compare_digest wants two byte strings
+        # of the same type, and encoding once avoids doing it on every request.
+        self._expected = token.encode("utf-8")
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        # `secrets.compare_digest` is constant-time in the length of the shorter
+        # input, so an attacker cannot learn the token one character at a time by
+        # measuring how long the comparison takes.
+        if secrets.compare_digest(token.encode("utf-8"), self._expected):
+            return AccessToken(token=token, client_id=_CLIENT_ID, scopes=[])
+        return None
+
+
+def build_http_auth(settings: SageSettings) -> AuthProvider | None:
+    """The auth provider for the HTTP transports, or None when auth is off.
+
+    Returns None unless ``http_auth_token`` is configured, so the FastMCP app is
+    unauthenticated by default -- the posture SECURITY.md describes. The returned
+    provider guards the MCP endpoint; the ``/health`` and ``/ready`` probes are
+    plain app routes and stay open, which is what a load balancer needs.
+    """
+    token = settings.http_auth_token
+    if not token:
+        return None
+    return StaticBearerTokenVerifier(token)

--- a/src/sagemath_mcp/config.py
+++ b/src/sagemath_mcp/config.py
@@ -33,6 +33,18 @@ def _bool_from_env(name: str, default: bool) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _optional_str_from_env(name: str) -> str | None:
+    """A secret-like string, or None when unset or blank.
+
+    A blank or whitespace-only value reads as "not configured" -- an empty
+    `SAGEMATH_MCP_HTTP_AUTH_TOKEN=` from a shell or compose file must not enable
+    auth with an empty password. The value is otherwise returned exactly, not
+    stripped: a token is opaque bytes, not something to normalise.
+    """
+    raw = os.getenv(name)
+    return raw if raw and raw.strip() else None
+
+
 @dataclass(slots=True)
 class SageSettings:
     """Runtime settings for Sage session management."""
@@ -58,6 +70,12 @@ class SageSettings:
     force_python_worker: bool = False
     persist_sessions: bool = False
     persist_dir: str = ""
+    # Optional bearer token for the HTTP transports. None (the default) leaves the
+    # endpoint unauthenticated -- the deliberate posture: the container is the
+    # boundary, keep it on loopback (SECURITY.md). Set it, and every MCP request
+    # must carry `Authorization: Bearer <token>`; the `/health` and `/ready`
+    # probes stay open. See `auth.py`.
+    http_auth_token: str | None = None
 
     @classmethod
     def from_env(cls) -> SageSettings:
@@ -88,6 +106,7 @@ class SageSettings:
             persist_dir=os.getenv(
                 "SAGEMATH_MCP_PERSIST_DIR", defaults["persist_dir"]
             ),
+            http_auth_token=_optional_str_from_env("SAGEMATH_MCP_HTTP_AUTH_TOKEN"),
         )
 
 

--- a/src/sagemath_mcp/server.py
+++ b/src/sagemath_mcp/server.py
@@ -190,6 +190,30 @@ def _register_health_route() -> None:
     LOGGER.debug("Registered /health endpoint")
 
 
+# Addresses that mean "only this machine". Binding anything else on an HTTP
+# transport exposes the evaluator beyond the host.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "::ffff:127.0.0.1"})
+
+
+def _exposure_warning(host: str, has_auth: bool) -> str | None:
+    """The warning to log for an HTTP bind, or None when the bind is safe.
+
+    Binding a non-loopback host publishes an unauthenticated code evaluator to
+    whatever can route to it. Inside a container that is the correct bind -- the
+    host maps a loopback-published port to it -- but on a bare host it is a hole.
+    Warn unless the bind is loopback, or a bearer token is required.
+    """
+    if has_auth or host in _LOOPBACK_HOSTS:
+        return None
+    return (
+        f"HTTP transport is binding {host!r} with NO authentication -- anyone who "
+        "can reach this address can execute code. This is only safe behind a "
+        "loopback-published container port or an authenticating proxy. Require a "
+        "token with SAGEMATH_MCP_HTTP_AUTH_TOKEN, or bind locally with "
+        "--host 127.0.0.1."
+    )
+
+
 def main(argv: list[str] | None = None) -> None:  # pragma: no cover - CLI entrypoint
     parser = argparse.ArgumentParser(description="Run the SageMath MCP server.")
     parser.add_argument(
@@ -220,6 +244,12 @@ def main(argv: list[str] | None = None) -> None:  # pragma: no cover - CLI entry
         if args.path:
             transport_kwargs["path"] = args.path
         _register_health_route()
+        has_auth = mcp.auth is not None
+        if has_auth:
+            LOGGER.info("HTTP bearer-token authentication is enabled.")
+        warning = _exposure_warning(args.host, has_auth)
+        if warning:
+            LOGGER.warning(warning)
 
     mcp.run(transport=args.transport, **transport_kwargs)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,71 @@
+"""Optional HTTP bearer-token authentication.
+
+The default posture is no auth (the container is the boundary); these tests pin
+the opt-in path: the token is off unless configured, a wrong token is refused, a
+right token is accepted, and binding a public host without a token is warned
+about. See `src/sagemath_mcp/auth.py` and SECURITY.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sagemath_mcp.auth import StaticBearerTokenVerifier, build_http_auth
+from sagemath_mcp.config import SageSettings
+from sagemath_mcp.server import _exposure_warning
+
+
+def test_build_http_auth_is_off_by_default() -> None:
+    """No token configured -> no auth provider, so the app is unauthenticated."""
+    assert build_http_auth(SageSettings()) is None
+
+
+def test_build_http_auth_returns_a_verifier_when_a_token_is_set() -> None:
+    provider = build_http_auth(SageSettings(http_auth_token="s3cret-token"))
+    assert isinstance(provider, StaticBearerTokenVerifier)
+
+
+async def test_the_configured_token_is_accepted() -> None:
+    verifier = StaticBearerTokenVerifier("s3cret-token")
+    access = await verifier.verify_token("s3cret-token")
+    assert access is not None
+    assert access.token == "s3cret-token"
+
+
+@pytest.mark.parametrize(
+    "presented",
+    ["", "wrong", "s3cret-toke", "s3cret-token ", "S3CRET-TOKEN"],
+)
+async def test_any_other_token_is_refused(presented: str) -> None:
+    """A near-miss, a prefix, a trailing space, the wrong case -- all rejected."""
+    verifier = StaticBearerTokenVerifier("s3cret-token")
+    assert await verifier.verify_token(presented) is None
+
+
+def test_an_empty_token_cannot_be_configured() -> None:
+    """An empty secret would authenticate everyone; refuse to build it."""
+    with pytest.raises(ValueError, match="non-empty"):
+        StaticBearerTokenVerifier("")
+
+
+async def test_a_unicode_token_round_trips() -> None:
+    # The token is compared as UTF-8 bytes, so non-ASCII secrets work end to end.
+    verifier = StaticBearerTokenVerifier("clé-secrète-éè")
+    assert await verifier.verify_token("clé-secrète-éè") is not None
+    assert await verifier.verify_token("cle-secrete-ee") is None
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "::ffff:127.0.0.1"])
+def test_loopback_binds_are_never_warned(host: str) -> None:
+    assert _exposure_warning(host, has_auth=False) is None
+
+
+def test_a_public_bind_without_auth_is_warned() -> None:
+    warning = _exposure_warning("0.0.0.0", has_auth=False)
+    assert warning is not None
+    assert "NO authentication" in warning
+    assert "SAGEMATH_MCP_HTTP_AUTH_TOKEN" in warning
+
+
+def test_a_public_bind_with_auth_is_not_warned() -> None:
+    assert _exposure_warning("0.0.0.0", has_auth=True) is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ def _clear_env(monkeypatch):
         "SAGEMATH_MCP_SHUTDOWN_GRACE",
         "SAGEMATH_MCP_MAX_STDOUT",
         "SAGEMATH_MCP_FORCE_PYTHON_WORKER",
+        "SAGEMATH_MCP_HTTP_AUTH_TOKEN",
     ]:
         monkeypatch.delenv(key, raising=False)
 
@@ -48,3 +49,24 @@ def test_bool_flag_parsing(monkeypatch, raw_value, expected):
     monkeypatch.setenv("SAGEMATH_MCP_FORCE_PYTHON_WORKER", raw_value)
     settings = SageSettings.from_env()
     assert settings.force_python_worker is expected
+
+
+def test_http_auth_token_defaults_to_none(monkeypatch):
+    """Unset -> no token -> the HTTP endpoint is unauthenticated by default."""
+    _clear_env(monkeypatch)
+    assert SageSettings.from_env().http_auth_token is None
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+def test_http_auth_token_blank_reads_as_unset(monkeypatch, blank):
+    """A bare `SAGEMATH_MCP_HTTP_AUTH_TOKEN=` must not enable auth with no secret."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("SAGEMATH_MCP_HTTP_AUTH_TOKEN", blank)
+    assert SageSettings.from_env().http_auth_token is None
+
+
+def test_http_auth_token_is_taken_verbatim(monkeypatch):
+    """A configured token is used exactly, not stripped -- it is opaque bytes."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("SAGEMATH_MCP_HTTP_AUTH_TOKEN", "  s3cret-token  ")
+    assert SageSettings.from_env().http_auth_token == "  s3cret-token  "


### PR DESCRIPTION
## Optional HTTP bearer-token authentication (opt-in)

Closes the "Optional HTTP auth" TODO item. **No authentication stays the deliberate default** — the container is the boundary, keep the endpoint on loopback (SECURITY.md). This adds one opt-in refinement for anyone fronting the HTTP endpoint on a network.

### What it does
Set `SAGEMATH_MCP_HTTP_AUTH_TOKEN=<secret>` and every MCP request over the HTTP transports must then carry `Authorization: Bearer <secret>`. The `/health` and `/ready` probes stay open so a load balancer can reach them. Unset (the default) → the endpoint is unauthenticated, exactly as before.

### Implementation
- **`auth.py`** — `StaticBearerTokenVerifier`, a fastmcp `TokenVerifier` that compares the configured token in **constant time** (`secrets.compare_digest`) and never logs it. `build_http_auth(settings)` returns it only when a token is set, else `None`.
- **`config.py`** — `http_auth_token` from `SAGEMATH_MCP_HTTP_AUTH_TOKEN`; a blank/whitespace value reads as **unset**, so an empty env var can't enable auth with no secret. The token is otherwise taken verbatim (opaque bytes).
- **`app.py`** — `FastMCP(auth=build_http_auth(runtime.SETTINGS))` — `None` by default, so the app is unauthenticated unless configured.
- **`server.py`** — `_exposure_warning` logs a **loud warning** when an HTTP transport binds a non-loopback host with no token, making the Dockerfile's container-internal `--host 0.0.0.0` an explicit, noted choice.
- **`Dockerfile`** — a comment explaining the `0.0.0.0` bind is container-internal and pointing at the auth opt-in.

### Verified end-to-end
Driven against the ASGI app in-process (no port bind needed):

| Request | Result |
|---|---|
| `GET /health` (no token) | **200** — probe stays open |
| `POST /mcp` no token | **401** |
| `POST /mcp` wrong token | **401** |
| `POST /mcp` correct token | **200** |

Plus unit tests for the verifier (accept/refuse/near-miss/empty/unicode), `build_http_auth`, the env parsing, and the exposure warning. **1048 tests, 100% coverage, lint clean.**

### Not changed
It's a single shared secret — an API key, not an OAuth server (no rotation, scopes or per-user identity) — and it guards the **transport**, not the process: it does not replace the container boundary or TLS. Docs: SECURITY.md (model + assumptions) and USAGE.md (how to enable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYaDocYYsXJGbSqv7vb3Ns
